### PR TITLE
[Feat] #6 - 등록탭 기본 화면 추가

### DIFF
--- a/KickGo/KickGo.xcodeproj/project.pbxproj
+++ b/KickGo/KickGo.xcodeproj/project.pbxproj
@@ -165,7 +165,7 @@
 				INFOPLIST_KEY_UIMainStoryboardFile = "";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -197,7 +197,7 @@
 				INFOPLIST_KEY_UIMainStoryboardFile = "";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/KickGo/KickGo/Controller/RegisterViewController.swift
+++ b/KickGo/KickGo/Controller/RegisterViewController.swift
@@ -1,12 +1,87 @@
 import UIKit
 import SnapKit
 
+
 class RegisterViewController: UIViewController {
+    let registerView = RegisterView()
+    let registerLocationSettingView = RegisterLocateSettingView()
+    let registerCheck = RegisterCheck()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .systemBackground
+        view.backgroundColor = bgColor
         title = "등록"
+        configureUI()
+        setupView()
+        settingView()
+        buttonTappeds()
     }
+    // 초기 뷰 셋팅
+    func settingView() {
+        registerView.isHidden = false
+        registerLocationSettingView.isHidden = true
+        registerCheck.isHidden = true
+    }
+    
+    func configureUI() {
+        view.addSubview(registerView)
+        view.addSubview(registerLocationSettingView)
+        view.addSubview(registerCheck)
+    }
+    func setupView() {
+        registerView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        registerLocationSettingView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        registerCheck.snp.makeConstraints{
+            $0.edges.equalToSuperview()
+        }
+    }
+    
+    func buttonTappeds(){
+        // registerView의 다음 버튼 (*취소버튼 추가)
+        registerView.nextButton.addTarget(self, action: #selector(goNext), for: .touchUpInside)
+        
+        // registerLocatinSetting(위치설정)의 다음,이전 버튼
+        registerLocationSettingView.nextButton.addTarget(self, action: #selector(goNext), for: .touchUpInside)
+        registerLocationSettingView.prevButton.addTarget(self, action: #selector(goPrev), for: .touchUpInside)
+        
+        // RegisterCheck의 이전 버튼 (*완료버튼 추가)
+        registerCheck.prevButton.addTarget(self, action: #selector(goPrev), for: .touchUpInside)
+    }
+    
+    
+    @objc func goNext(){
+        if registerView.isHidden == false{
+            registerView.isHidden = true
+            registerLocationSettingView.isHidden = false
+            registerCheck.isHidden = true
+        } else if registerLocationSettingView.isHidden == false{
+            registerView.isHidden = true
+            registerLocationSettingView.isHidden = true
+            registerCheck.isHidden = false
+        } else if registerCheck.isHidden == false{
+            //완료 알럿 함수 나타내기
+        }
+    }
+    @objc func goPrev(){
+        if registerLocationSettingView.isHidden == false{
+            registerView.isHidden = false
+            registerLocationSettingView.isHidden = true
+            registerCheck.isHidden = true
+        } else if registerCheck.isHidden == false{
+            registerView.isHidden = true
+            registerLocationSettingView.isHidden = false
+            registerCheck.isHidden = true
+        }
+    }
+    
+    // 완료 알럿 함수 만들기
+
 }
 
-
+#Preview {
+    RegisterViewController()
+}

--- a/KickGo/KickGo/RegisterTap/Color.swift
+++ b/KickGo/KickGo/RegisterTap/Color.swift
@@ -1,0 +1,7 @@
+import UIKit
+
+
+let bgColor = UIColor(cgColor: CGColor(red: 243/255, green: 244/255, blue: 246/255, alpha: 1))
+let viewNumsColor = UIColor(cgColor: CGColor(red: 37/255, green: 99/255, blue: 235/255, alpha: 1))
+let greenAlertColor = UIColor(cgColor: CGColor(red: 236/255, green: 253/255, blue: 245/255, alpha: 1))
+let greenTextColor = UIColor(red: 16/255, green: 185/255, blue: 129/255, alpha: 1)

--- a/KickGo/KickGo/RegisterTap/RegisterCheckCell.swift
+++ b/KickGo/KickGo/RegisterTap/RegisterCheckCell.swift
@@ -1,0 +1,82 @@
+
+import Foundation
+import UIKit
+import SnapKit
+
+class RegisterCheckCell: UITableViewCell {
+    
+    static let identifier = "RegisterCheckCell"
+    
+    // 모델명
+    let modelLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: 14)
+        label.textColor = .darkGray
+        return label
+    }()
+    
+    // 시리얼 넘버
+    let serialLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: 14)
+        label.textColor = .darkGray
+        return label
+    }()
+    // 배터리
+    let batteryLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: 14)
+        label.textColor = .darkGray
+        return label
+    }()
+    
+    // 배치 위치
+    let positionLabel: UILabel = {
+        let label = UILabel()
+        label.font = UIFont.systemFont(ofSize: 14)
+        label.textColor = .darkGray
+        return label
+    }()
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: .default, reuseIdentifier: reuseIdentifier)
+        configureUI()
+        setupLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func configureUI(){
+        [modelLabel,serialLabel,batteryLabel,positionLabel].forEach{
+            contentView.addSubview($0)
+        }
+    }
+    
+    func setupLayout(){
+        modelLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().inset(20)
+            $0.centerY.equalToSuperview()
+        }
+        
+        serialLabel.snp.makeConstraints {
+            $0.trailing.equalToSuperview().inset(20)
+            $0.centerY.equalToSuperview()
+        }
+        batteryLabel.snp.makeConstraints {
+            $0.trailing.equalToSuperview().inset(20)
+            $0.centerY.equalToSuperview()
+        }
+        positionLabel.snp.makeConstraints {
+            $0.leading.trailing.equalTo(modelLabel)
+            $0.bottom.equalToSuperview()
+            $0.height.equalTo(1)
+        }
+    }
+    
+    public func configure(title: String, value: String) {
+        modelLabel.text = title
+        serialLabel.text = value
+    }
+}

--- a/KickGo/KickGo/RegisterTap/Views/RegisterCheck.swift
+++ b/KickGo/KickGo/RegisterTap/Views/RegisterCheck.swift
@@ -1,0 +1,222 @@
+
+import Foundation
+import UIKit
+import SnapKit
+
+class RegisterCheck: UIView, UITableViewDelegate, UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return infoDummyData.count
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: RegisterCheckCell.identifier, for: indexPath) as? RegisterCheckCell else {
+            return UITableViewCell()
+        }
+        let item = infoDummyData[indexPath.row]
+        cell.configure(title: item.title, value: item.value)
+        return cell
+    }
+    
+    
+    //[이후 교체] 테이블 뷰 더미 데이터
+    let infoDummyData: [(title: String, value: String)] = [
+        ("모델명", "KickGo Pro Max"),
+        ("시리얼 번호", "KR-12345-ABC"),
+        ("배터리", "87%"),
+        ("배치 위치", "서울시 강남구")
+    ]
+    
+    //상단 숫자
+    let numsLabel: UILabel = {
+        let label = UILabel()
+        label.backgroundColor = viewNumsColor
+        label.textColor = .white
+        label.text = "3"
+        label.textAlignment = .center
+        label.layer.cornerRadius = 16
+        label.layer.masksToBounds = true
+        return label
+    }()
+    // 등록 완료 label
+    let infoLabel: UILabel = {
+        let label = UILabel()
+        label.text = "등록 완료"
+        label.font = UIFont.systemFont(ofSize: 24, weight: .bold)
+        return label
+    }()
+    //등록 정보 확인 상세설명 label
+    let detailLabel: UILabel = {
+        let label = UILabel()
+        label.text = "입력한 정보를 확인해주세요."
+        return label
+    }()
+    
+    //하단 이전, 등록완료 컨테이너뷰
+    let bottomContainerView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .white
+        return view
+    }()
+    
+    let prevButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("이전", for: .normal)
+        button.titleLabel?.font = .systemFont(ofSize: 16, weight: .bold)
+        button.setTitleColor(.darkGray, for: .normal)
+        button.backgroundColor = bgColor
+        button.layer.cornerRadius = 12
+        return button
+    }()
+    
+    let finishButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("등록완료", for: .normal)
+        button.titleLabel?.font = .systemFont(ofSize: 16, weight: .bold)
+        button.setTitleColor(.darkGray, for: .normal)
+        button.backgroundColor = bgColor
+        button.layer.cornerRadius = 12
+        return button
+    }()
+    
+    //등록 정보 확인 테이블 뷰
+    lazy var infoTableView: UITableView = {
+        let tableView = UITableView()
+        tableView.backgroundColor = .white
+        tableView.isScrollEnabled = false
+        tableView.layer.cornerRadius = 16
+        tableView.separatorStyle = .none
+        tableView.register(RegisterCheckCell.self, forCellReuseIdentifier: RegisterCheckCell.identifier)
+        return tableView
+    }()
+    
+    //등록 완료 준비 컨테이너 뷰
+    let checkInfoContainerView: UIView = {
+        let view = UIView()
+        view.backgroundColor = greenAlertColor
+        view.layer.cornerRadius = 12
+        return view
+    }()
+    
+    // 등록 완료 준비 제목 label
+    let checkInfoLabel: UILabel = {
+        let label = UILabel()
+        label.text = "등록 완료 준비"
+        label.font = .systemFont(ofSize: 20, weight: .bold)
+        label.textColor = greenTextColor
+        
+        return label
+    }()
+    // 등록 완료 준비 서브 label
+    let checkInfoSubLabel: UILabel = {
+        let label = UILabel()
+        label.text = "위 정보로 킥보드를 등록하시겠습니까? 등록 후에도 위치는 언제든 변경할 수 있습니다."
+        label.font = .systemFont(ofSize: 14, weight: .regular)
+        label.textColor = greenTextColor
+        label.numberOfLines = 0
+        return label
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupTableView()
+        configureUI()
+        setupLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func configureUI() {
+        //self(RegisterLocateSettingView)에 상속
+        [numsLabel, infoLabel, detailLabel,checkInfoContainerView,infoTableView,bottomContainerView].forEach{
+            self.addSubview($0)
+        }
+        //bottomContainerView에 상속
+        [prevButton,finishButton].forEach{
+            bottomContainerView.addSubview($0)
+        }
+        
+        // checkInfoContainerView에 상속
+        [checkInfoLabel,checkInfoSubLabel].forEach{
+            checkInfoContainerView.addSubview($0)
+        }
+        
+    }
+    func setupLayout() {
+        numsLabel.snp.makeConstraints{
+            $0.top.equalTo(safeAreaLayoutGuide).inset(20)
+            $0.width.height.equalTo(32)
+            $0.centerX.equalToSuperview()
+        }
+        infoLabel.snp.makeConstraints{
+            $0.top.equalTo(numsLabel.snp.bottom).offset(30)
+            $0.centerX.equalToSuperview()
+        }
+        detailLabel.snp.makeConstraints{
+            $0.top.equalTo(infoLabel.snp.bottom).offset(10)
+            $0.centerX.equalToSuperview()
+        }
+        bottomContainerView.snp.makeConstraints{
+            $0.leading.trailing.equalToSuperview()
+            $0.bottom.equalTo(self.safeAreaLayoutGuide)
+            $0.top.equalTo(prevButton.snp.top).offset(-16)
+        }
+        
+        infoTableView.snp.makeConstraints {
+            $0.top.equalTo(detailLabel.snp.bottom).offset(20)
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.height.equalTo(240)
+            
+        }
+        
+        checkInfoContainerView.snp.makeConstraints {
+            $0.top.equalTo(infoTableView.snp.bottom).offset(20)
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.bottom.equalTo(checkInfoContainerView.snp.top).offset(-20)
+            $0.height.equalTo(140)
+        }
+        bottomContainerSetUpLayout()
+        checkInfoContainerSetUpLayout()
+    }
+    
+    //bottomContainerView 하위 요소 오토레이아웃 설정
+    func bottomContainerSetUpLayout() {
+        // 이전 버튼
+        prevButton.snp.makeConstraints {
+            $0.height.equalTo(50)
+            $0.centerY.equalToSuperview()
+            $0.leading.equalToSuperview().inset(20)
+            $0.trailing.equalTo(finishButton.snp.leading).offset(-20)
+        }
+        // 다음 버튼
+        finishButton.snp.makeConstraints {
+            $0.width.equalTo(prevButton)
+            $0.centerY.height.equalTo(prevButton)
+            $0.trailing.equalToSuperview().inset(20)
+            $0.leading.equalTo(prevButton.snp.trailing).offset(20)
+            
+        }
+    }
+    
+    func checkInfoContainerSetUpLayout() {
+        checkInfoLabel.snp.makeConstraints {
+            $0.top.leading.trailing.equalToSuperview().inset(30)
+        }
+        checkInfoSubLabel.snp.makeConstraints {
+            $0.top.equalTo(checkInfoLabel.snp.bottom)
+            $0.leading.trailing.equalTo(checkInfoLabel)
+            $0.bottom.equalToSuperview().inset(40)
+        }
+    }
+    
+    //테이블 뷰 delegate, dataSource 설정
+    private func setupTableView() {
+        infoTableView.delegate = self
+        infoTableView.dataSource = self
+        infoTableView.rowHeight = 60
+    }
+}
+#Preview{
+    RegisterCheck()
+}

--- a/KickGo/KickGo/RegisterTap/Views/RegisterLocateSetting.swift
+++ b/KickGo/KickGo/RegisterTap/Views/RegisterLocateSetting.swift
@@ -1,0 +1,202 @@
+
+import Foundation
+import UIKit
+import NMapsMap
+import SnapKit
+
+class RegisterLocateSettingView: UIView{
+    //상단 숫자
+    let numsLabel: UILabel = {
+        let label = UILabel()
+        label.backgroundColor = viewNumsColor
+        label.textColor = .white
+        label.text = "2"
+        label.textAlignment = .center
+        label.layer.cornerRadius = 16
+        label.layer.masksToBounds = true
+        return label
+    }()
+    // 위치 설정 label
+    let infoLabel: UILabel = {
+        let label = UILabel()
+        label.text = "위치 설정"
+        label.font = UIFont.systemFont(ofSize: 24, weight: .bold)
+        return label
+    }()
+    //킥보드 배치 상세설명 label
+    let detailLabel: UILabel = {
+        let label = UILabel()
+        label.text = "킥보드를 배치할 위치를 선택해주세요."
+        return label
+    }()
+    
+    //하단 이전, 다음 컨테이너뷰
+    let bottomContainerView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .white
+        return view
+    }()
+    
+    let prevButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("이전", for: .normal)
+        button.titleLabel?.font = .systemFont(ofSize: 16, weight: .bold)
+        button.setTitleColor(.darkGray, for: .normal)
+        button.backgroundColor = bgColor
+        button.layer.cornerRadius = 12
+        return button
+    }()
+    
+    let nextButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("다음", for: .normal)
+        button.titleLabel?.font = .systemFont(ofSize: 16, weight: .bold)
+        button.setTitleColor(.darkGray, for: .normal)
+        button.backgroundColor = bgColor
+        button.layer.cornerRadius = 12
+        return button
+    }()
+    
+    // 배치 위치 검색 컨테이너
+    let searchContainerView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .white
+        return view
+    }()
+    
+    // 배치 위치 label
+    let searchLabel: UILabel = {
+        let label = UILabel()
+        label.text = "배치 위치"
+        return label
+    }()
+    // 배치 서치 textField
+    let searchTextField: UITextField = {
+        let textField = UITextField()
+        textField.borderStyle = .roundedRect
+        textField.autocapitalizationType = .none
+        textField.backgroundColor = bgColor
+        textField.placeholder = "예: 강남역 2번 출구"
+        return textField
+    }()
+    //배치 위치 확인 버튼
+    let searchButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("확인", for: .normal)
+        button.titleLabel?.font = .systemFont(ofSize: 16, weight: .bold)
+        button.setTitleColor(.darkGray, for: .normal)
+        button.backgroundColor = bgColor
+        button.layer.cornerRadius = 12
+        return button
+    }()
+    // 서치한 위치의 지도 나타내는 uiView
+    let mapView: NMFMapView = {
+        let view = NMFMapView()
+        view.backgroundColor = .white
+        return view
+    }()
+    
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureUI()
+        setupLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func configureUI() {
+        //self(RegisterLocateSettingView)에 상속
+        [numsLabel, infoLabel, detailLabel,searchContainerView,bottomContainerView,mapView].forEach{
+            self.addSubview($0)
+        }
+        //bottomContainerView에 상속
+        [prevButton,nextButton].forEach{
+            bottomContainerView.addSubview($0)
+        }
+        
+        //searchContainerView에 상속
+        [searchLabel,searchTextField,searchButton].forEach{
+            searchContainerView.addSubview($0)
+        }
+        
+    }
+    func setupLayout() {
+        numsLabel.snp.makeConstraints{
+            $0.top.equalTo(safeAreaLayoutGuide).inset(30)
+            $0.width.height.equalTo(32)
+            $0.centerX.equalToSuperview()
+        }
+        infoLabel.snp.makeConstraints{
+            $0.top.equalTo(numsLabel.snp.bottom).offset(30)
+            $0.centerX.equalToSuperview()
+        }
+        detailLabel.snp.makeConstraints{
+            $0.top.equalTo(infoLabel.snp.bottom).offset(10)
+            $0.centerX.equalToSuperview()
+        }
+        
+        searchContainerView.snp.makeConstraints{
+            $0.top.equalTo(detailLabel.snp.bottom).offset(20)
+            $0.leading.trailing.equalTo(safeAreaLayoutGuide).inset(20)
+        }
+        
+        bottomContainerView.snp.makeConstraints{
+            $0.leading.trailing.equalToSuperview()
+            $0.bottom.equalTo(self.safeAreaLayoutGuide)
+            $0.top.equalTo(prevButton.snp.top).offset(-16)
+        }
+        mapView.snp.makeConstraints {
+            $0.top.equalTo(searchContainerView.snp.bottom).offset(20)
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.bottom.equalTo(bottomContainerView.snp.top)
+        }
+        searchContainerSetUpLayout()
+        bottomContainerSetUpLayout()
+    }
+    //searchContainerView 요소 오토 레이아웃 설정
+    func searchContainerSetUpLayout() {
+        //searchLabel,searchTextField,searchButton
+        searchLabel.snp.makeConstraints{
+            $0.top.equalToSuperview().inset(20)
+            $0.leading.trailing.equalToSuperview().inset(20)
+        }
+        
+        searchTextField.snp.makeConstraints{
+            $0.top.equalTo(searchLabel.snp.bottom).offset(20)
+            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.height.equalTo(60)
+    
+        }
+        
+        searchButton.snp.makeConstraints{
+            $0.top.equalTo(searchTextField.snp.bottom).offset(20)
+            $0.leading.trailing.equalTo(searchTextField)
+            $0.height.equalTo(50)
+            $0.bottom.equalToSuperview().inset(20)
+        }
+    }
+    
+    //bottomContainerView 하위 요소 오토레이아웃 설정
+    func bottomContainerSetUpLayout() {
+        // 이전 버튼
+        prevButton.snp.makeConstraints {
+            $0.height.equalTo(50)
+            $0.centerY.equalToSuperview()
+            $0.leading.equalToSuperview().inset(20)
+            $0.trailing.equalTo(nextButton.snp.leading).offset(-20)
+        }
+        // 다음 버튼
+        nextButton.snp.makeConstraints {
+            $0.width.equalTo(prevButton)
+            $0.centerY.height.equalTo(prevButton)
+            $0.trailing.equalToSuperview().inset(20)
+            $0.leading.equalTo(prevButton.snp.trailing).offset(20)
+            
+        }
+    }
+    
+
+}

--- a/KickGo/KickGo/RegisterTap/Views/RegisterView.swift
+++ b/KickGo/KickGo/RegisterTap/Views/RegisterView.swift
@@ -1,0 +1,221 @@
+
+import Foundation
+import UIKit
+import SnapKit
+
+class RegisterView: UIView {
+    
+    //상단 숫자
+    let numsLabel: UILabel = {
+        let label = UILabel()
+        label.backgroundColor = viewNumsColor
+        label.textColor = .white
+        label.text = "1"
+        label.textAlignment = .center
+        label.layer.cornerRadius = 16
+        label.layer.masksToBounds = true
+        return label
+    }()
+    // 킥보드 정보 label
+    let infoLabel: UILabel = {
+        let label = UILabel()
+        label.text = "킥보드 정보"
+        label.font = UIFont.systemFont(ofSize: 24, weight: .bold)
+        return label
+    }()
+    //킥보드 정보 상세설명 label
+    let detailLabel: UILabel = {
+        let label = UILabel()
+        label.text = "킥보드의 기본 정보를 입력해주세요."
+        return label
+    }()
+    
+    //킥보드 정보 입력 컨테이너 뷰
+    let registerContainerView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .white
+        view.layer.cornerRadius = 20
+        return view
+    }()
+    //킥보드 모델명 label,textField
+    let modelNameLabel: UILabel = {
+        let label = UILabel()
+        label.text = "킥보드 모델명"
+        return label
+    }()
+    let modelNameTextField: UITextField = {
+        let textField = UITextField()
+        textField.borderStyle = .roundedRect
+        textField.backgroundColor = bgColor
+        textField.placeholder = "예: KickGo Pro Max"
+        textField.autocapitalizationType = .none
+        return textField
+    }()
+    
+    //시리얼 번호 label,textField
+    let serialNumberLabel: UILabel = {
+        let label = UILabel()
+        label.text = "시리얼 번호"
+        return label
+    }()
+    let serialNumberTextField: UITextField = {
+        let textField = UITextField()
+        textField.borderStyle = .roundedRect
+        textField.backgroundColor = bgColor
+        textField.placeholder = "킥보드에 표시된 시리얼 번호를 입력하세요."
+        textField.autocapitalizationType = .none
+        return textField
+    }()
+    //배터리 잔량(%) label, textField
+    let batteryLabel: UILabel = {
+        let label = UILabel()
+        label.text = "배터리 잔량(%)"
+        return label
+    }()
+    
+    let batteryTextField: UITextField = {
+        let textField = UITextField()
+        textField.borderStyle = .roundedRect
+        textField.backgroundColor = bgColor
+        textField.placeholder = "현재 배터리 잔량을 입력하세요."
+        textField.autocapitalizationType = .none
+        return textField
+    }()
+    
+    //하단 취소, 다음 컨테이너뷰
+    let bottomContainerView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .white
+        return view
+    }()
+    
+    let cancelButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("취소", for: .normal)
+        button.titleLabel?.font = .systemFont(ofSize: 16, weight: .bold)
+        button.setTitleColor(.darkGray, for: .normal)
+        button.backgroundColor = bgColor
+        button.layer.cornerRadius = 12
+        return button
+    }()
+    
+    let nextButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.setTitle("다음", for: .normal)
+        button.titleLabel?.font = .systemFont(ofSize: 16, weight: .bold)
+        button.setTitleColor(.darkGray, for: .normal)
+        button.backgroundColor = bgColor
+        button.layer.cornerRadius = 12
+        return button
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        configureUI()
+        setupLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func configureUI() {
+        //self(RegisterView)에 상속
+        [numsLabel, infoLabel, detailLabel,registerContainerView,bottomContainerView].forEach{
+            self.addSubview($0)
+        }
+        //registerContainerView에 상속
+        [modelNameLabel,modelNameTextField, serialNumberLabel, serialNumberTextField, batteryLabel, batteryTextField].forEach{
+            registerContainerView.addSubview($0)
+        }
+        //bottomContainerView에 상속
+        [cancelButton,nextButton].forEach{
+            bottomContainerView.addSubview($0)
+        }
+        
+    }
+    func setupLayout() {
+        numsLabel.snp.makeConstraints{
+            $0.top.equalTo(safeAreaLayoutGuide).inset(30)
+            $0.width.height.equalTo(32)
+            $0.centerX.equalToSuperview()
+        }
+        infoLabel.snp.makeConstraints{
+            $0.top.equalTo(numsLabel.snp.bottom).offset(30)
+            $0.centerX.equalToSuperview()
+        }
+        detailLabel.snp.makeConstraints{
+            $0.top.equalTo(infoLabel.snp.bottom).offset(10)
+            $0.centerX.equalToSuperview()
+        }
+        registerContainerView.snp.makeConstraints{
+            $0.top.equalTo(detailLabel.snp.bottom).offset(30)
+            $0.leading.trailing.equalTo(safeAreaLayoutGuide).inset(20)
+        }
+        bottomContainerView.snp.makeConstraints{
+            $0.leading.trailing.equalToSuperview()
+            $0.bottom.equalTo(self.safeAreaLayoutGuide)
+            $0.top.equalTo(cancelButton.snp.top).offset(-16)
+        }
+        
+        registerSetUpLayout()
+        bottomContainerSetUpLayout()
+    }
+    
+    
+    //registerContainerView 하위 요소 오토레이아웃 설정
+    func registerSetUpLayout() {
+        
+        // 모델명
+        modelNameLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(20)
+            $0.leading.trailing.equalToSuperview().inset(20)
+        }
+        modelNameTextField.snp.makeConstraints {
+            $0.top.equalTo(modelNameLabel.snp.bottom).offset(20)
+            $0.leading.trailing.equalTo(modelNameLabel)
+            $0.height.equalTo(50)
+        }
+        
+        // 시리얼 번호
+        serialNumberLabel.snp.makeConstraints {
+            $0.top.equalTo(modelNameTextField.snp.bottom).offset(20)
+            $0.leading.trailing.equalTo(modelNameLabel)
+        }
+        serialNumberTextField.snp.makeConstraints {
+            $0.top.equalTo(serialNumberLabel.snp.bottom).offset(20)
+            $0.leading.trailing.equalTo(modelNameLabel)
+            $0.height.equalTo(50)
+        }
+        
+        // 배터리 잔량
+        batteryLabel.snp.makeConstraints {
+            $0.top.equalTo(serialNumberTextField.snp.bottom).offset(20)
+            $0.leading.trailing.equalTo(modelNameLabel)
+        }
+        batteryTextField.snp.makeConstraints {
+            $0.top.equalTo(batteryLabel.snp.bottom).offset(20)
+            $0.leading.trailing.equalTo(modelNameLabel)
+            $0.height.equalTo(50)
+            $0.bottom.equalToSuperview().inset(20)
+        }
+    }
+    
+    //bottomContainerView 하위 요소 오토레이아웃 설정
+    func bottomContainerSetUpLayout() {
+        // 취소 버튼
+        cancelButton.snp.makeConstraints {
+            $0.height.equalTo(50)
+            $0.centerY.equalToSuperview()
+            $0.leading.equalToSuperview().inset(20)
+        }
+        // 다음 버튼
+        nextButton.snp.makeConstraints {
+            $0.width.equalTo(cancelButton)
+            $0.centerY.height.equalTo(cancelButton)
+            $0.trailing.equalToSuperview().inset(20)
+            $0.leading.equalTo(cancelButton.snp.trailing).offset(20)
+            
+        }
+    }
+}


### PR DESCRIPTION
### 작업한 내용

> 해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

킥보드 신규 등록 플로우 UI 구현
좌측 부터
킥보드 등록, 키보드 등록(위치 설정), 키보드 등록(등록 체크) 화면을 구현하였고
각 화면은 별도의 UIView로 분리하여 관리하며 RegisterViewController에서 화면을 전환합니다.

킥보드 등록(RegisterView): 
킥보드 모델명, 시리얼 번호, 배터리 잔량 등 기본 정보를 입력받는 UI를 구현했습니다.

키보드 등록(위치 설정)(RegisterLocateSettingView): 
Naver Maps SDK(NMFMapView)를 사용하여 킥보드를 배치할 위치를 검색하고 지도에 표시하는 UI를 구현했습니다.

키보드 등록(등록 체크)(RegisterCheck): 
이전에 입력한 모든 정보를 UITableView를 통해 사용자에게 다시 한번 확인시켜주는 UI를 구현했습니다.

추후 데이터는 코어데이터로 관리할 예정입니다.

<img width="180" height="378" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-10-14 at 17 05 59" src="https://github.com/user-attachments/assets/dcc3d4e1-5623-4dd8-81a7-7e05407dae7b" />

<img width="180" height="378" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-10-14 at 17 06 01" src="https://github.com/user-attachments/assets/dddd2c70-5836-4e55-99db-c940b60a3366" />
<img width="180" height="378" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-10-14 at 17 15 04" src="https://github.com/user-attachments/assets/11691847-f68c-42f6-a3ea-0ba7f9c143b0" />



### 관련 이슈

Closes #6 

### PR 올리기 전 Check List

**Merge 대상 브랜치가 올바른가? 네**

작업한 코드가 에러 없이 잘 동작하는가? 네
