### PR TITLE
[Feat] #24 - 내가 등록한 킥보드 리스트 표시

### DIFF
--- a/KickGo/KickGo/Controller/MyRegisterListViewController.swift
+++ b/KickGo/KickGo/Controller/MyRegisterListViewController.swift
@@ -1,0 +1,53 @@
+import UIKit
+import CoreData
+import SnapKit
+
+class MyRegisterListViewController: UIViewController, UITableViewDataSource {
+    private var scooters: [ScooterEntity] = []
+    private let tableView = UITableView()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "내가 등록한 킥보드"
+        view.backgroundColor = .systemBackground
+
+        setupTableView()
+        fetchScooters()
+    }
+
+    private func setupTableView() {
+        view.addSubview(tableView)
+        tableView.dataSource = self
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "cell")
+        tableView.snp.makeConstraints { make in
+            make.edges.equalTo(view.safeAreaLayoutGuide)
+        }
+    }
+
+    private func fetchScooters() {
+        let context = CoreDataStack.context
+        let request: NSFetchRequest<ScooterEntity> = ScooterEntity.fetchRequest()
+
+        do {
+            scooters = try context.fetch(request)
+            tableView.reloadData()
+        } catch {
+            print("불러오기 실패:", error)
+        }
+    }
+
+    // 테이블뷰 데이터소스
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return scooters.count
+    }
+    
+    // 나중에 수정+삭제 UI를 간소화하기 위해서 테이블뷰형태로 만들었습니다!
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = UITableViewCell(style: .subtitle, reuseIdentifier: "cell")
+        let s = scooters[indexPath.row]
+        cell.textLabel?.text = "\(s.modelName ?? "모델 입력X") - \(s.serialNumber ?? "") (\(s.battery)% )"
+        cell.detailTextLabel?.text = s.position // 위치는 밑에 작은 글씨로 표시해줌
+        return cell
+    }
+}
+

--- a/KickGo/KickGo/Controller/MyViewController.swift
+++ b/KickGo/KickGo/Controller/MyViewController.swift
@@ -257,9 +257,7 @@ class MyViewController: UIViewController {
     }
 
     @objc private func openMyScooters() {
-        let vc = UIViewController()
-        vc.title = "내가 등록한 킥보드"
-        vc.view.backgroundColor = .systemBackground
+        let vc = MyRegisterListViewController()
         navigationController?.pushViewController(vc, animated: true)
     }
 


### PR DESCRIPTION
### 작업한 내용

> 해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

`MyRegisterListViewController`를 새로 만들어서
테이블뷰 형태로 데이터 등록하고 표시하는 기본적인 메서드들을 추가했습니다!

UI는 이후 브랜치에서 추가로 수정할 예정입니다.

초반 와이어프레임을 제작할 때 화면전환을 생각안해서
개발하다보니까 뷰컨트롤러 개수가 점점 많아지는데;;; 
이용내역의 데이터 수정이랑 삭제는 화면전환없이 셀 수정/스와이프 삭제로 처리할 생각입니다,,,,

등록탭에서 같은 킥보드에 대해서 등록완료 버튼을 두번눌렀을 때 중복으로 저장되는 문제가 있는데
등록완료 버튼을 눌렀을 때 등록탭 1번 화면으로 돌아가게 하면 될 것 같습니다.



<img width="200" height="500" alt="Simulator Screenshot - iPhone 16 Pro - 2025-10-15 at 14 40 43" src="https://github.com/user-attachments/assets/4750b7c5-4e00-4674-b330-e77f6ae658fe" />


### 관련 이슈

Closes #24 

### PR 올리기 전 Check List

**Merge 대상 브랜치가 올바른가?** 네

작업한 코드가 에러 없이 잘 동작하는가? 네
