### PR TITLE
[Feat] #39 - 로그아웃 버튼 활성화

### DIFF
--- a/KickGo/KickGo/Controller/MyViewController.swift
+++ b/KickGo/KickGo/Controller/MyViewController.swift
@@ -270,7 +270,17 @@ class MyViewController: UIViewController {
 
         let cancel = UIAlertAction(title: "취소", style: .cancel, handler: nil)
         let logout = UIAlertAction(title: "로그아웃", style: .destructive) { _ in
-            // 여기에 실제 로그아웃 로직이 나중에 들어갈 예정..
+            // 로그인 화면으로 이동
+            let loginVC = LoginViewController()
+            let nav = UINavigationController(rootViewController: loginVC)
+            nav.modalPresentationStyle = .fullScreen
+            
+            // 현재 윈도우의 루트뷰컨트롤러 교체
+            if let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate,
+               let window = sceneDelegate.window {
+                window.rootViewController = nav
+                window.makeKeyAndVisible()
+            }
             print("로그아웃 완료")
         }
 


### PR DESCRIPTION
### 작업한 내용

> 해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

마이탭의 뷰컨트롤러에서 로그인뷰컨트롤러를 호출하는 객체를 만들고 
현재 윈도우의 루트 뷰컨트롤러를 교체하는 코드를 추가했습니다.

로그인 화면에서 메인화면으로 진입하려면 실제 로그인 로직이 들어가야되는데 아직 없어서

메인화면으로 돌아가려면 다시 빌드하시면 됩니다!

<img width="200" height="500" alt="Simulator Screenshot - iPhone 16 Pro - 2025-10-15 at 17 17 05" src="https://github.com/user-attachments/assets/b74fa544-a239-44c1-a1f1-210f0c6d01bc" />

<img width="200" height="500" alt="Simulator Screenshot - iPhone 16 Pro - 2025-10-15 at 17 17 10" src="https://github.com/user-attachments/assets/fe184a84-c92b-49e0-a501-1ab309ac5b0c" />

### 관련 이슈

Closes #39 

### PR 올리기 전 Check List

**Merge 대상 브랜치가 올바른가?** 네

작업한 코드가 에러 없이 잘 동작하는가? 네
