### PR TITLE
[Fix] #37 - 등록탭 초기화

### DIFF
--- a/KickGo/KickGo/Controller/RegisterViewController.swift
+++ b/KickGo/KickGo/Controller/RegisterViewController.swift
@@ -2,13 +2,24 @@ import UIKit
 import SnapKit
 import CoreData
 
-class RegisterViewController: UIViewController {
+class RegisterViewController: UIViewController,RegisterCheckDelegate {
+    func registerCheckDidTapNext() -> [(title: String, value: String)] {
+        return[
+            ("모델명", registerView.modelNameTextField.text ?? ""),
+            ("시리얼 번호", registerView.serialNumberTextField.text ?? ""),
+            ("배터리", registerView.batteryTextField.text ?? ""),
+            ("배치 위치", registerLocationSettingView.searchTextField.text ?? "")
+        ]
+    }
+    
+    
     let registerView = RegisterView()
     let registerLocationSettingView = RegisterLocateSettingView()
     let registerCheck = RegisterCheck()
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        registerCheck.delegate = self
         view.backgroundColor = ColorF3F4F6
         title = "등록"
         configureUI()
@@ -56,14 +67,17 @@ class RegisterViewController: UIViewController {
     
     
     @objc func goNext(){
+        
         if registerView.isHidden == false{
             registerView.isHidden = true
             registerLocationSettingView.isHidden = false
             registerCheck.isHidden = true
+            registerCheck.reloadData()
         } else if registerLocationSettingView.isHidden == false{
             registerView.isHidden = true
             registerLocationSettingView.isHidden = true
             registerCheck.isHidden = false
+            registerCheck.reloadData()
         } else if registerCheck.isHidden == false{
             //완료 알럿 함수 나타내기
         }
@@ -104,16 +118,33 @@ class RegisterViewController: UIViewController {
         do {
             try context.save()
             showAlert(title: "등록 완료", message: "킥보드 정보가 저장되었습니다.")
+            resetRegistrationForm()
         } catch {
             print("저장 실패: \(error)")
+            
         }
     }
 
 
     // 등록완료 알럿
-    func showAlert(title: String, message: String) {
+    func showAlert(title: String, message: String, completion: (() -> Void)? = nil) {
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: "확인", style: .default))
+        
+        let completAction = UIAlertAction(title: "확인", style: .default) { (_) in
+            completion?()
+        }
+        alert.addAction(completAction)
         present(alert, animated: true)
     }
+    //등록 화면 데이터 초기화
+    private func resetRegistrationForm() {
+        
+        registerView.modelNameTextField.text = nil
+        registerView.serialNumberTextField.text = nil
+        registerView.batteryTextField.text = nil
+        registerLocationSettingView.searchTextField.text = nil
+        registerView.textFieldsChanged()
+        settingView()
+    }
+    
 }

--- a/KickGo/KickGo/RegisterTap/Views/RegisterCheck.swift
+++ b/KickGo/KickGo/RegisterTap/Views/RegisterCheck.swift
@@ -3,6 +3,10 @@ import Foundation
 import UIKit
 import SnapKit
 
+protocol RegisterCheckDelegate: AnyObject {
+    func registerCheckDidTapNext() -> [(title: String, value: String)]
+}
+
 class RegisterCheck: UIView, UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return infoDummyData.count
@@ -12,19 +16,14 @@ class RegisterCheck: UIView, UITableViewDelegate, UITableViewDataSource {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: RegisterCheckCell.identifier, for: indexPath) as? RegisterCheckCell else {
             return UITableViewCell()
         }
+        cell.selectionStyle = .none
         let item = infoDummyData[indexPath.row]
         cell.configure(title: item.title, value: item.value)
         return cell
     }
     
-    
-    //[이후 교체] 테이블 뷰 더미 데이터
-    let infoDummyData: [(title: String, value: String)] = [
-        ("모델명", "KickGo Pro Max"),
-        ("시리얼 번호", "KR-12345-ABC"),
-        ("배터리", "87%"),
-        ("배치 위치", "서울시 강남구")
-    ]
+    weak var delegate: RegisterCheckDelegate?
+    var infoDummyData: [(title: String, value: String)] = []
     
     //상단 숫자
     let numsLabel: UILabel = {
@@ -215,5 +214,10 @@ class RegisterCheck: UIView, UITableViewDelegate, UITableViewDataSource {
         infoTableView.delegate = self
         infoTableView.dataSource = self
         infoTableView.rowHeight = 60
+    }
+    
+    func reloadData(){
+        self.infoDummyData = delegate?.registerCheckDidTapNext() ?? []
+        self.infoTableView.reloadData()
     }
 }

--- a/KickGo/KickGo/RegisterTap/Views/RegisterLocateSetting.swift
+++ b/KickGo/KickGo/RegisterTap/Views/RegisterLocateSetting.swift
@@ -221,7 +221,7 @@ class RegisterLocateSettingView: UIView {
     private func setupTargets() {
         searchTextField.addTarget(self, action: #selector(textFieldChanged), for: .editingChanged)
         nextButton.isEnabled = false
-        nextButton.backgroundColor = UIColor(red: 229/255, green: 231/255, blue: 235/255, alpha: 1)
+        nextButton.backgroundColor = ColorE5E7EB
         nextButton.setTitleColor(.darkGray, for: .normal)
     }
 
@@ -230,7 +230,7 @@ class RegisterLocateSettingView: UIView {
         nextButton.isEnabled = hasText
         nextButton.backgroundColor = hasText
             ? UIColor(red: 0.145, green: 0.388, blue: 0.922, alpha: 1)
-            : UIColor(red: 229/255, green: 231/255, blue: 235/255, alpha: 1)
+            : ColorE5E7EB
         nextButton.setTitleColor(hasText ? .white : .darkGray, for: .normal)
     }
 
@@ -251,6 +251,7 @@ class RegisterLocateSettingView: UIView {
 
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
+        // 나중에 키값 보안을 위한 리팩토링 진행해야함
         request.addValue("oj5l1oliar", forHTTPHeaderField: "X-NCP-APIGW-API-KEY-ID")
         request.addValue("wndlYwoXCHG0cV6r465Jy502IN1rQZV2hslxhwMm", forHTTPHeaderField: "X-NCP-APIGW-API-KEY")
         request.addValue("application/json", forHTTPHeaderField: "Accept")

--- a/KickGo/KickGo/RegisterTap/Views/RegisterView.swift
+++ b/KickGo/KickGo/RegisterTap/Views/RegisterView.swift
@@ -82,21 +82,11 @@ class RegisterView: UIView {
         return textField
     }()
     
-    //하단 취소, 다음 컨테이너뷰
+    //다음 컨테이너뷰
     let bottomContainerView: UIView = {
         let view = UIView()
         view.backgroundColor = .white
         return view
-    }()
-    
-    let cancelButton: UIButton = {
-        let button = UIButton(type: .system)
-        button.setTitle("취소", for: .normal)
-        button.titleLabel?.font = .systemFont(ofSize: 16, weight: .bold)
-        button.setTitleColor(.darkGray, for: .normal)
-        button.backgroundColor = ColorF3F4F6
-        button.layer.cornerRadius = 12
-        return button
     }()
     
     let nextButton: UIButton = {
@@ -130,7 +120,7 @@ class RegisterView: UIView {
             registerContainerView.addSubview($0)
         }
         //bottomContainerView에 상속
-        [cancelButton,nextButton].forEach{
+        [nextButton].forEach{
             bottomContainerView.addSubview($0)
         }
         
@@ -156,7 +146,7 @@ class RegisterView: UIView {
         bottomContainerView.snp.makeConstraints{
             $0.leading.trailing.equalToSuperview()
             $0.bottom.equalTo(self.safeAreaLayoutGuide)
-            $0.top.equalTo(cancelButton.snp.top).offset(-16)
+            $0.top.equalTo(nextButton.snp.top).offset(-16)
         }
         
         registerSetUpLayout()
@@ -204,18 +194,14 @@ class RegisterView: UIView {
     
     //bottomContainerView 하위 요소 오토레이아웃 설정
     func bottomContainerSetUpLayout() {
-        // 취소 버튼
-        cancelButton.snp.makeConstraints {
-            $0.height.equalTo(50)
-            $0.centerY.equalToSuperview()
-            $0.leading.equalToSuperview().inset(20)
-        }
+
         // 다음 버튼
         nextButton.snp.makeConstraints {
-            $0.width.equalTo(cancelButton)
-            $0.centerY.height.equalTo(cancelButton)
+            $0.height.equalTo(60)
+            $0.centerY.equalToSuperview()
+            $0.leading.trailing.equalToSuperview().inset(20)
             $0.trailing.equalToSuperview().inset(20)
-            $0.leading.equalTo(cancelButton.snp.trailing).offset(20)
+            
             
         }
     }
@@ -229,10 +215,10 @@ class RegisterView: UIView {
 
         // 초기에는 비활성화 상태
         nextButton.isEnabled = false
-        nextButton.backgroundColor = UIColor(red: 229/255, green: 231/255, blue: 235/255, alpha: 1)
+        nextButton.backgroundColor = ColorE5E7EB
     }
 
-    @objc private func textFieldsChanged() {
+    @objc func textFieldsChanged() {
         // 세 칸 모두 입력되어야 활성화
         let filled = !(modelNameTextField.text?.isEmpty ?? true) &&
                      !(serialNumberTextField.text?.isEmpty ?? true) &&
@@ -243,11 +229,11 @@ class RegisterView: UIView {
         
         if filled {
             // 활성화 상태(정보를 다 입력했을 때)
-            nextButton.backgroundColor = UIColor(red: 0.145, green: 0.388, blue: 0.922, alpha: 1) // 피그마 #2563EB 색깔
+            nextButton.backgroundColor = Color2563EB
             nextButton.setTitleColor(.white, for: .normal)
         } else {
             // 비활성화 상태(정보 하나라도 누락됐을 때)
-            nextButton.backgroundColor = UIColor(red: 229/255, green: 231/255, blue: 235/255, alpha: 1) // 피그마 #E5E7EB 색깔
+            nextButton.backgroundColor = ColorE5E7EB
             nextButton.setTitleColor(.darkGray, for: .normal)
         }
         

--- a/KickGo/KickGo/Utils/Color.swift
+++ b/KickGo/KickGo/Utils/Color.swift
@@ -5,3 +5,4 @@ let ColorF3F4F6 = UIColor(cgColor: CGColor(red: 243/255, green: 244/255, blue: 2
 let Color2563EB = UIColor(cgColor: CGColor(red: 37/255, green: 99/255, blue: 235/255, alpha: 1))
 let ColorECFDF5 = UIColor(cgColor: CGColor(red: 236/255, green: 253/255, blue: 245/255, alpha: 1))
 let Color10B981 = UIColor(red: 16/255, green: 185/255, blue: 129/255, alpha: 1)
+let ColorE5E7EB = UIColor(red: 229/255, green: 231/255, blue: 235/255, alpha: 1)


### PR DESCRIPTION
### 작업한 내용

> 해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

등록이 성공적으로 완료되면, 모든 입력 폼을 초기화하고 등록 첫 화면으로 돌아가는 기능을 추가했습니다.
입력한 값이 마지막 테이블뷰에 나타나지 않는 부분도 Delegate 패턴을 이용하여 수정했습니다.

![Adobe Express - 화면 기록 2025-10-15 오후 5 25 07](https://github.com/user-attachments/assets/61fb226d-731a-41a3-bdb3-02d756be84fb)


### 관련 이슈

Closes #37

### PR 올리기 전 Check List

**Merge 대상 브랜치가 올바른가?** 네

작업한 코드가 에러 없이 잘 동작하는가? 네
