### PR TITLE
[Feat] #53 - 로그아웃 로직 추가

### DIFF
--- a/KickGo/KickGo/Controller/MyViewController.swift
+++ b/KickGo/KickGo/Controller/MyViewController.swift
@@ -361,12 +361,17 @@ class MyViewController: UIViewController {
 
         let cancel = UIAlertAction(title: "취소", style: .cancel, handler: nil)
         let logout = UIAlertAction(title: "로그아웃", style: .destructive) { _ in
-            // 로그인 화면으로 이동
+            // 1)로그인 상태 초기화
+            let defaults = UserDefaults.standard
+            defaults.removeObject(forKey: "isLoggedIn")
+            defaults.removeObject(forKey: "loggedInUserID")
+            
+            // 2)로그인 화면으로 이동
             let loginVC = LoginViewController()
             let nav = UINavigationController(rootViewController: loginVC)
             nav.modalPresentationStyle = .fullScreen
             
-            // 현재 윈도우의 루트뷰컨트롤러 교체
+            // 3)현재 윈도우의 루트뷰컨트롤러 교체
             if let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate,
                let window = sceneDelegate.window {
                 window.rootViewController = nav


### PR DESCRIPTION
### 작업한 내용

> 해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

이전에 만들어둔 마이탭 뷰컨트롤러의 logoutTapped 메서드에서

```
            // 1) 로그인 상태 초기화
            let defaults = UserDefaults.standard
            defaults.removeObject(forKey: "isLoggedIn")
            defaults.removeObject(forKey: "loggedInUserID")
            // 2),3)은 이전과 동일함
```

블럭을 추가해서 
isLoggedIn, loggedInUserID 자리에 저장된 데이터를 삭제해서 로그아웃 상태로 만들었습니다.

PR 작성하다가 도중에 발견했는데
로그인 뷰컨트롤러에 로그인 상태 저장하는 코드가 없어서 이후 브랜치에서 작업할 예정입니다.

### 관련 이슈

Closes #53

### PR 올리기 전 Check List

**Merge 대상 브랜치가 올바른가?** 네

작업한 코드가 에러 없이 잘 동작하는가? 네
