### PR TITLE
[Feat] #55 - 로그아웃 로직 수정, 회원탈퇴 로직 추가

### DIFF
--- a/KickGo/KickGo/Controller/LoginViewController.swift
+++ b/KickGo/KickGo/Controller/LoginViewController.swift
@@ -77,16 +77,6 @@ class LoginViewController: UIViewController {
         LoginButton.addTarget(self, action: #selector (loginButtonTapped), for: .touchUpInside)
         signUpButton.addTarget(self, action: #selector(signupButtonTapped), for: .touchUpInside)
         
-        //테스트 회원
-        let testdefaults = UserDefaults.standard
-        let testUser: [String : Any] = [
-            "name": "김킥고",
-            "id": "kickgo@example.com",
-            "phoneNums":"010-0000-0000",
-            "password": "1234"
-        ]
-        testdefaults.set(testUser, forKey: "kickgo@example.com")
-        
     }
     
     override func viewDidLayoutSubviews() {
@@ -188,7 +178,10 @@ class LoginViewController: UIViewController {
             return
         }
         if PasswordNameTextField.text == password {
-            print("로그인 성공")
+            // 로그인 상태 저장
+            UserDefaults.standard.set(true, forKey: "isLoggedIn")
+            UserDefaults.standard.set(id, forKey: "loggedInUserID")
+            
             navigationController?.pushViewController(mainVC, animated: true)
         } else {
             print("틀린 비밀번호")

--- a/KickGo/KickGo/Controller/MyViewController.swift
+++ b/KickGo/KickGo/Controller/MyViewController.swift
@@ -396,8 +396,30 @@ class MyViewController: UIViewController {
 
         let cancel = UIAlertAction(title: "취소", style: .cancel, handler: nil)
         let delete = UIAlertAction(title: "탈퇴하기", style: .destructive) { _ in
-            // 여기에 실제 탈퇴 처리 로직이 나중에 들어갈 예정..
-            print("회원탈퇴 완료")
+            let defaults = UserDefaults.standard
+            
+            // 현재 로그인된 유저 ID 가져오기
+            if let userID = defaults.string(forKey: "loggedInUserID") {
+                // 해당 유저 정보 삭제
+                defaults.removeObject(forKey: userID)
+            }
+            
+            // 로그인 상태 초기화(로그아웃 로직이랑 같음)
+            defaults.removeObject(forKey: "isLoggedIn")
+            defaults.removeObject(forKey: "loggedInUserID")
+            
+            // 로그인 화면으로 이동(로그아웃 로직이랑 같음)
+            let loginVC = LoginViewController()
+            let nav = UINavigationController(rootViewController: loginVC)
+            nav.modalPresentationStyle = .fullScreen
+            
+            // 현재 윈도우의 루트뷰컨트롤러 교체(로그아웃 로직이랑 같음)
+            if let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate,
+               let window = sceneDelegate.window {
+                window.rootViewController = nav
+                window.makeKeyAndVisible()
+            }
+            
         }
 
         alert.addAction(cancel)


### PR DESCRIPTION
### 작업한 내용

> 해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

테스트용 계정 관련코드 제거했고
로그아웃 버튼 로직과 동일하게 deleteAccountTapped 메서드에 회원탈퇴 로직 추가해줌

아래 블럭만 다르고 나머지는 로그아웃 버튼 메서드랑 같음
```swift
            // 현재 로그인된 유저 ID 가져오기
            if let userID = defaults.string(forKey: "loggedInUserID") {
                // 해당 유저 정보 삭제
                defaults.removeObject(forKey: userID)
            }
```

그리고 로그아웃 뷰컨트롤러에서, 
if PasswordNameTextField.text == password 일 때 아래 블럭 추가해줌

```swift
            // 로그인 상태 저장
            UserDefaults.standard.set(true, forKey: "isLoggedIn")
            UserDefaults.standard.set(id, forKey: "loggedInUserID")
```

**로그인 상태 저장은 굳이싶지만 회원탈퇴하는 과정에서 유저 ID 가져올 때 필요함!!**

### 관련 이슈

Closes #55 

### PR 올리기 전 Check List

**Merge 대상 브랜치가 올바른가?** 네

작업한 코드가 에러 없이 잘 동작하는가? 네
