### PR TITLE
[Fix] #59 - 회원별 등록데이터 분리,삭제

### DIFF
--- a/KickGo/KickGo/Controller/MyRegisterListViewController.swift
+++ b/KickGo/KickGo/Controller/MyRegisterListViewController.swift
@@ -32,6 +32,11 @@ class MyRegisterListViewController: UIViewController, UITableViewDataSource {
         let context = CoreDataStack.context
         let request: NSFetchRequest<ScooterEntity> = ScooterEntity.fetchRequest()
 
+        // 현재 로그인한 회원 ID로 필터링하기(필터링하면 계정마다 계정에 해당하는 정보가 보여짐)
+        if let userID = UserDefaults.standard.string(forKey: "loggedInUserID") {
+            request.predicate = NSPredicate(format: "ownerID == %@", userID)
+        }
+
         do {
             scooters = try context.fetch(request)
             tableView.reloadData()
@@ -39,6 +44,7 @@ class MyRegisterListViewController: UIViewController, UITableViewDataSource {
             print("불러오기 실패:", error)
         }
     }
+
 
     // 테이블뷰 데이터소스
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {

--- a/KickGo/KickGo/Controller/MyViewController.swift
+++ b/KickGo/KickGo/Controller/MyViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import SnapKit
+import CoreData
 
 // 재사용하는 메뉴 행 뷰 클래스
 class MenuRowView: UIControl {
@@ -394,37 +395,44 @@ class MyViewController: UIViewController {
             preferredStyle: .alert
         )
 
-        let cancel = UIAlertAction(title: "취소", style: .cancel, handler: nil)
+        let cancel = UIAlertAction(title: "취소", style: .cancel)
         let delete = UIAlertAction(title: "탈퇴하기", style: .destructive) { _ in
             let defaults = UserDefaults.standard
-            
-            // 현재 로그인된 유저 ID 가져오기
-            if let userID = defaults.string(forKey: "loggedInUserID") {
-                // 해당 유저 정보 삭제
-                defaults.removeObject(forKey: userID)
+            guard let userID = defaults.string(forKey: "loggedInUserID") else { return }
+
+            // 코어데이터에서 해당 회원의 킥보드 삭제
+            let context = CoreDataStack.context
+            let request: NSFetchRequest<ScooterEntity> = ScooterEntity.fetchRequest()
+            request.predicate = NSPredicate(format: "ownerID == %@", userID)
+            do {
+                let scooters = try context.fetch(request)
+                scooters.forEach { context.delete($0) }
+                try context.save()
+                print("\(userID)의 킥보드 전부 삭제 완료")
+            } catch {
+                print("코어데이터 삭제 오류:", error)
             }
-            
-            // 로그인 상태 초기화(로그아웃 로직이랑 같음)
+
+            // 유저디폴트 회원정보 및 로그인상태 삭제
+            defaults.removeObject(forKey: userID)
             defaults.removeObject(forKey: "isLoggedIn")
             defaults.removeObject(forKey: "loggedInUserID")
-            
-            // 로그인 화면으로 이동(로그아웃 로직이랑 같음)
+
+            // 로그인화면으로 이동
             let loginVC = LoginViewController()
             let nav = UINavigationController(rootViewController: loginVC)
             nav.modalPresentationStyle = .fullScreen
-            
-            // 현재 윈도우의 루트뷰컨트롤러 교체(로그아웃 로직이랑 같음)
             if let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate,
                let window = sceneDelegate.window {
                 window.rootViewController = nav
                 window.makeKeyAndVisible()
             }
-            
         }
 
         alert.addAction(cancel)
         alert.addAction(delete)
         present(alert, animated: true)
     }
+
 }
 

--- a/KickGo/KickGo/Controller/RegisterViewController.swift
+++ b/KickGo/KickGo/Controller/RegisterViewController.swift
@@ -103,15 +103,18 @@ class RegisterViewController: UIViewController,RegisterCheckDelegate {
         
         scooter.setValue(registerView.modelNameTextField.text ?? "", forKey: "modelName")
         scooter.setValue(registerView.serialNumberTextField.text ?? "", forKey: "serialNumber")
-
         
+        // 현재 로그인된 계정 ID 저장
+        if let userID = UserDefaults.standard.string(forKey: "loggedInUserID") {
+            scooter.setValue(userID, forKey: "ownerID")
+        }
+
         if let batteryText = registerView.batteryTextField.text,
            let batteryValue = Int(batteryText) {
             scooter.setValue(batteryValue, forKey: "battery")
         } else {
             scooter.setValue(0, forKey: "battery")
         }
-
         
         scooter.setValue(registerLocationSettingView.searchTextField.text ?? "", forKey: "position")
 
@@ -121,9 +124,9 @@ class RegisterViewController: UIViewController,RegisterCheckDelegate {
             resetRegistrationForm()
         } catch {
             print("저장 실패: \(error)")
-            
         }
     }
+
 
 
     // 등록완료 알럿

--- a/KickGo/KickGo/Model/CoreDataStack.swift
+++ b/KickGo/KickGo/Model/CoreDataStack.swift
@@ -5,11 +5,19 @@ enum CoreDataStack {
     // PersistentContainer 생성
     static let persistentContainer: NSPersistentContainer = {
         let container = NSPersistentContainer(name: "KickGoModel")
+
+        // 마이그레이션 옵션 추가(모델파일 수정하면서 같이 추가함)
+        if let description = container.persistentStoreDescriptions.first {
+            description.setOption(true as NSNumber, forKey: NSMigratePersistentStoresAutomaticallyOption)
+            description.setOption(true as NSNumber, forKey: NSInferMappingModelAutomaticallyOption)
+        }
+
         container.loadPersistentStores { _, error in
             if let error = error {
                 fatalError("코어데이터 로드 실패: \(error)")
             }
         }
+
         return container
     }()
 

--- a/KickGo/KickGo/Model/KickGoModel.xcdatamodeld/KickGoModel.xcdatamodel/contents
+++ b/KickGo/KickGo/Model/KickGoModel.xcdatamodeld/KickGoModel.xcdatamodel/contents
@@ -3,6 +3,7 @@
     <entity name="ScooterEntity" representedClassName="ScooterEntity" syncable="YES" codeGenerationType="class">
         <attribute name="battery" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="modelName" optional="YES" attributeType="String"/>
+        <attribute name="ownerID" optional="YES" attributeType="String"/>
         <attribute name="position" optional="YES" attributeType="String"/>
         <attribute name="serialNumber" optional="YES" attributeType="String"/>
     </entity>


### PR DESCRIPTION
### 작업한 내용

> 해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

계정바이계정으로 각 계정에는 해당회원이 등록한 데이터만 보여지게함
**= 한 기기에서 여러 계정으로 로그인하더라도 회원별로 본인의 등록킥보드 데이터만 조회가능**

**회원탈퇴 시 해당 회원의 코어데이터(등록한 킥보드), 유저디폴트(회원정보)가 삭제됨x**

### 수정파일

KickGoModel.xcdatamodeld 수정함: 모델파일에서 엔티티에 ownerID(스트링)이라는 속성을 추가함.(해당 데이터가 어느 회원에 속하는지 구분하기 위해서)

CoreDataStack.swift 수정함: 경량 마이그레이션.. 이라는 옵션을 추가했는데 이게 모델파일의 엔티티 변경할 때 추가해주는 옵션이라고 합니다! 
> https://masterpiece-programming.tistory.com/343 블로그글 참고했습니다.


RegisterViewController.swift 수정함: 킥보드 등록 시 ownerID 저장 추가

MyRegisterListViewController.swift 수정함: 등록한 킥보드 목록 조회 시에 ownerID 기반으로 필터링해서 보여줌

MyViewController.swift 수정함: 회원탈퇴 시 코어데이터+유저디폴트 삭제 로직 추가

### 관련 이슈

Closes #59 

### PR 올리기 전 Check List

**Merge 대상 브랜치가 올바른가?** 네

작업한 코드가 에러 없이 잘 동작하는가? 네