### PR TITLE
[Feat] #58 - 마이탭 프로필헤더에 회원정보 표시

### DIFF
--- a/KickGo/KickGo/Controller/MyViewController.swift
+++ b/KickGo/KickGo/Controller/MyViewController.swift
@@ -144,10 +144,8 @@ class MyViewController: UIViewController {
         avatar.snp.makeConstraints { $0.size.equalTo(56) }
 
         nameLabel.font = .boldSystemFont(ofSize: 22)
-        nameLabel.text = "김킥고님"
         emailLabel.font = .systemFont(ofSize: 14)
         emailLabel.textColor = .secondaryLabel
-        emailLabel.text = "kickgo@example.com"
 
         let v = UIStackView(arrangedSubviews: [nameLabel, emailLabel])
         v.axis = .vertical
@@ -433,6 +431,26 @@ class MyViewController: UIViewController {
         alert.addAction(delete)
         present(alert, animated: true)
     }
+    
+    // viewWillAppear
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        // 현재 로그인한 사용자 ID(이메일) 가져오기
+        let defaults = UserDefaults.standard
+        guard let userID = defaults.string(forKey: "loggedInUserID"),
+              let userDict = defaults.dictionary(forKey: userID),
+              let name = userDict["name"] as? String,
+              let email = userDict["id"] as? String else {
+            print("로그인된 사용자 정보를 불러올 수 없습니다.")
+            return
+        }
+
+        // 프로필헤더 UI 업데이트(이름, 이메일)
+        nameLabel.text = "\(name)님"
+        emailLabel.text = email
+    }
+
 
 }
 


### PR DESCRIPTION
### 작업한 내용

> 해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

원래 프로필헤더는 UI만 있었고

```swift
nameLabel.text = "김킥고님"
emailLabel.text = "kickgo@example.com"
```
이렇게 하드코딩되어있었음->이 부분 삭제함

`MyViewController.swift`에서 마지막 부분에 viewWillAppear 블럭 추가해서
로그인 하고 계정전환할 때마다 최신 계정 정보가 표시되도록 만듦

```swift
override func viewWillAppear(_ animated: Bool) {
    super.viewWillAppear(animated)
    
    // 현재 로그인한 사용자 ID(이메일) 가져오기
    let defaults = UserDefaults.standard
    guard let userID = defaults.string(forKey: "loggedInUserID"),
          let userDict = defaults.dictionary(forKey: userID),
          let name = userDict["name"] as? String,
          let email = userDict["id"] as? String else {
        print("로그인된 사용자 정보를 불러올 수 없습니다.")
        return
    }

    // 프로필헤더 UI 업데이트
    nameLabel.text = "\(name)님"
    emailLabel.text = email
}
```

<img width="200" height="500" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-10-16 at 16 37 41" src="https://github.com/user-attachments/assets/cd000fd6-d20f-408d-9383-7ef06d5bc308" />
<img width="200" height="500" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-10-16 at 16 38 00" src="https://github.com/user-attachments/assets/eccb5e57-4051-4aa2-a571-57c3ff438306" />

### 관련 이슈

Closes #58 

### PR 올리기 전 Check List

**Merge 대상 브랜치가 올바른가?** 네

작업한 코드가 에러 없이 잘 동작하는가? 네
