### PR TITLE
[Feat] #65 - 이용한 킥보드 기록 저장하는 엔티티 만들고 임시테이블뷰로 보여주기

### DIFF
--- a/KickGo/KickGo/Controller/MyViewController.swift
+++ b/KickGo/KickGo/Controller/MyViewController.swift
@@ -338,9 +338,7 @@ class MyViewController: UIViewController {
 
     // 이용내역 버튼 액션
     @objc private func openHistory() {
-        let vc = UIViewController()
-        vc.title = "이용 내역"
-        vc.view.backgroundColor = .systemBackground
+        let vc = RentalHistoryViewController()
         navigationController?.pushViewController(vc, animated: true)
     }
     

--- a/KickGo/KickGo/Controller/RentalHistoryViewController.swift
+++ b/KickGo/KickGo/Controller/RentalHistoryViewController.swift
@@ -1,0 +1,93 @@
+import UIKit
+import CoreData
+
+class RentalHistoryViewController: UIViewController {
+
+    // 사용할 프로퍼티들
+    private var rentals: [RentalScooterEntity] = []      // 표시할 데이터
+    private let tableView = UITableView()                // 테이블뷰
+
+    // viewDidLoad
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "이용 내역"
+        view.backgroundColor = .systemBackground
+
+        setupTableView()     // 테이블뷰 만들기 (넣을 자리)
+        setupDummyData()     // 임시 더미데이터 (넣는 내용)
+    }
+
+    // 테이블뷰 셋업
+    private func setupTableView() {
+        tableView.dataSource = self
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "cell")
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.estimatedRowHeight = 80
+        view.addSubview(tableView)
+        tableView.frame = view.bounds
+    }
+
+    // 더미데이터(나중에 삭제할예정!! 이 부분 코드는 무시해도 괜찮습니다..)
+    private func setupDummyData() {
+        let ctx = CoreDataStack.context
+
+        let dummy1 = RentalScooterEntity(context: ctx)
+        dummy1.id = UUID()
+        dummy1.userEmail = "kickgo@example.com"
+        dummy1.scooterModel = "킥고 라이트"
+        dummy1.startTime = Date().addingTimeInterval(-3600)
+        dummy1.endTime = Date()
+        dummy1.duration = 30
+        dummy1.payment = 2500
+
+        let dummy2 = RentalScooterEntity(context: ctx)
+        dummy2.id = UUID()
+        dummy2.userEmail = "kickgo@example.com"
+        dummy2.scooterModel = "킥고 맥스"
+        dummy2.startTime = Date().addingTimeInterval(-7200)
+        dummy2.endTime = Date().addingTimeInterval(-6900)
+        dummy2.duration = 5
+        dummy2.payment = 700
+
+        try? ctx.save()
+        rentals = [dummy1, dummy2]
+    }
+}
+
+// 테이블뷰 데이터소스
+extension RentalHistoryViewController: UITableViewDataSource {
+    
+    // 테이블뷰에서 셀 몇 개 만들어야되는지
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        rentals.count
+    }
+    
+    // 테이블뷰 꾸미기
+    func tableView(_ tableView: UITableView,
+                   cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+
+        let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
+        let record = rentals[indexPath.row]
+
+        // 날짜
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MM/dd HH:mm"
+
+        // 옵셔널 처리
+        let start = record.startTime.map { formatter.string(from: $0) } ?? "-"
+        let end = record.endTime.map { formatter.string(from: $0) } ?? "-"
+
+        // 텍스트라벨
+        cell.textLabel?.numberOfLines = 0
+        cell.textLabel?.font = .systemFont(ofSize: 15)
+        cell.textLabel?.text =
+        """
+        이용일시: \(start) ~ \(end)
+        이용시간: \(Int(record.duration))분
+        결제금액: \(record.payment)원
+        """
+
+        return cell
+    }
+}
+

--- a/KickGo/KickGo/Model/KickGoModel.xcdatamodeld/KickGoModel.xcdatamodel/contents
+++ b/KickGo/KickGo/Model/KickGoModel.xcdatamodeld/KickGoModel.xcdatamodel/contents
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23788.4" systemVersion="24G90" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithSwiftData="YES" userDefinedModelVersionIdentifier="">
+    <entity name="RentalScooterEntity" representedClassName="RentalScooterEntity" syncable="YES" codeGenerationType="class">
+        <attribute name="duration" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="endTime" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="payment" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="scooterModel" optional="YES" attributeType="String"/>
+        <attribute name="startTime" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="userEmail" optional="YES" attributeType="String"/>
+    </entity>
     <entity name="ScooterEntity" representedClassName="ScooterEntity" syncable="YES" codeGenerationType="class">
         <attribute name="battery" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="modelName" optional="YES" attributeType="String"/>


### PR DESCRIPTION
### 작업한 내용

> 해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

1. 대여했던 킥보드 기록을 코어데이터를 사용해서 저장->표시할 예정
2. 1번기능이 아직 없으니까 더미데이터 넣어서 UI 간단하게 그리기
3. 근데 넣기전에 모델파일에 엔티티 있어야됨

그래서 모델파일에 새로운 엔티티를 추가하게 됨

ScooterEntity(원래 있던거)
**RentalScooterEntity <<이게 추가됨**

이 엔티티에는 대여했던 기록 하나를 나타내는 데이터들을 저장함
**코드 읽어보면 어떤거 저장하는지 확인가능**


**그리고 마이탭의 뷰컨트롤러에서 이용내역 누르면 이용내역 뷰컨트롤러로 가도록 설정해놨고
여기 들어가면 아래 사진처럼 임시 가짜데이터를 넣어놓은 테이블뷰를 볼 수 있음**

테이블뷰 UI랑 실제 대여기능 연결은 추가 작업할 예정

<img width="200" height="500" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-10-16 at 19 40 41" src="https://github.com/user-attachments/assets/f5f31a79-5103-4f64-8847-2588537151b1" />


kickgo@example.com
1234


로 테스트 해보세요!!


### 관련 이슈

Closes #65 

### PR 올리기 전 Check List

**Merge 대상 브랜치가 올바른가?** 네

작업한 코드가 에러 없이 잘 동작하는가? 네
