### PR TITLE
[Feat] #68 - 대여하기 Alert 띄우기

### DIFF
--- a/KickGo/KickGo/Controller/MarkerSheetViewController.swift
+++ b/KickGo/KickGo/Controller/MarkerSheetViewController.swift
@@ -76,6 +76,7 @@ class MarkerSheetViewController: UIViewController {
         rentButton.setTitleColor(.white, for: .normal)
         rentButton.backgroundColor = UIColor(red: 37/255, green: 99/255, blue: 235/255, alpha: 1)
         rentButton.layer.cornerRadius = 14
+        rentButton.addTarget(self, action: #selector(didTapRentButton), for: .touchUpInside)
         
         // 닫기 버튼
         let config = UIImage.SymbolConfiguration(pointSize: 11, weight: .medium)
@@ -166,5 +167,17 @@ class MarkerSheetViewController: UIViewController {
         fullStack.spacing = 4
         
         return fullStack
+    }
+}
+
+// 대여하기 눌렀을 때 코드를 구현하면 코드 길이가 좀 생길 것 같아서 extension으로 따로 빼놨습니다!
+extension MarkerSheetViewController {
+    @objc func didTapRentButton() {
+        let alert = UIAlertController(title: nil, message: "해당 킥보드를 대여하시겠습니까?", preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "취소", style: .default))
+        alert.addAction(UIAlertAction(title: "대여하기", style: .default) { [weak self] _ in
+            print("확인")
+        })
+        present(alert, animated: true)
     }
 }


### PR DESCRIPTION
### 작업한 내용

> 해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

킥보드 마커를 누른 후 `대여하기 버튼`을 누르면 대여 여부를 물어보는 Alert을 띄웠습니다.
취소 -> Alert 사라짐
확인 -> 마이페이지 이용 상태가 '이용중'으로 변함 (구현 필요)

<img width="200" height="500" alt="image" src="https://github.com/user-attachments/assets/8bd9353e-7763-4d36-8f1b-c65e5c301f31" />


### 관련 이슈

Closes #68 

### PR 올리기 전 Check List

**Merge 대상 브랜치가 올바른가?** 네

작업한 코드가 에러 없이 잘 동작하는가? 네