### PR TITLE
[Feat]#72 - 마지막 로그인 정보 로그아웃 후 데이터 남기기

### DIFF
--- a/KickGo/KickGo/Controller/LoginViewController.swift
+++ b/KickGo/KickGo/Controller/LoginViewController.swift
@@ -75,6 +75,7 @@ class LoginViewController: UIViewController {
         
         hideKeyboardWhenTappedAround()
         setupUI()
+        lastLoginfo()
         LoginButton.addTarget(self, action: #selector (loginButtonTapped), for: .touchUpInside)
         signUpButton.addTarget(self, action: #selector(signupButtonTapped), for: .touchUpInside)
         
@@ -177,9 +178,21 @@ class LoginViewController: UIViewController {
             UserDefaults.standard.set(true, forKey: "isLoggedIn")
             UserDefaults.standard.set(id, forKey: "loggedInUserID")
             
+            UserDefaults.standard.set(id, forKey: "lastUseEmail")
+            UserDefaults.standard.set(textFieldPassword, forKey: "lastUsePassword")
+            
             navigationController?.pushViewController(mainVC, animated: true)
         } else {
             showAlert(title: "로그인 실패", message: "비밀번호가 올바르지 않습니다.")
+        }
+    }
+    
+    private func lastLoginfo(){
+        if let lastUsedEmail = UserDefaults.standard.string(forKey: "lastUseEmail"){
+            IDTextField.text = lastUsedEmail
+        }
+        if let lastUsedPassword = UserDefaults.standard.string(forKey: "lastUsePassword"){
+            PasswordNameTextField.text = lastUsedPassword
         }
     }
 


### PR DESCRIPTION
### 작업한 내용

> 해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

로그인이 완료되면 UserDefaults에 아이디와 비번을 저장해서 이후 로그인할 때 아이디와 비번이 자동으로 입력되어 있도록 합니다.
로그인 성공 시, 현재 이메일과 비밀번호를 UserDefaults에 저장하는 로직을 추가
lastLoginfo() 메서드를 새로 추가하여 viewDidLoad() 시점에 UserDefaults에 저장된 마지막 로그인 정보를 불러와 IDTextField와 PasswordNameTextField에 각각 설정


![Adobe Express - 화면 기록 2025-10-17 오전 9 16 21](https://github.com/user-attachments/assets/1d0ba336-a02c-4467-883c-b65ca106c118)



### 관련 이슈

Closes #72 

### PR 올리기 전 Check List

**Merge 대상 브랜치가 올바른가?** 네

작업한 코드가 에러 없이 잘 동작하는가? 네
