### PR TITLE
[Feat] #74 - 킥보드 대여 시 프로필 상태카드 업데이트

### DIFF
--- a/KickGo/KickGo/Controller/MarkerSheetViewController.swift
+++ b/KickGo/KickGo/Controller/MarkerSheetViewController.swift
@@ -173,11 +173,30 @@ class MarkerSheetViewController: UIViewController {
 // 대여하기 눌렀을 때 코드를 구현하면 코드 길이가 좀 생길 것 같아서 extension으로 따로 빼놨습니다!
 extension MarkerSheetViewController {
     @objc func didTapRentButton() {
-        let alert = UIAlertController(title: nil, message: "해당 킥보드를 대여하시겠습니까?", preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: "취소", style: .default))
-        alert.addAction(UIAlertAction(title: "대여하기", style: .default) { [weak self] _ in
-            print("확인")
+        let alert = UIAlertController(
+            title: nil,
+            message: "해당 킥보드를 대여하시겠습니까?",
+            preferredStyle: .alert
+        )
+
+        alert.addAction(UIAlertAction(title: "취소", style: .cancel))
+        alert.addAction(UIAlertAction(title: "대여하기", style: .default) { _ in
+            let defaults = UserDefaults.standard
+
+            // 현재 로그인한 계정의 아이디 가져오기
+            if let userID = defaults.string(forKey: "loggedInUserID") {
+                // 계정별 상태값(이용중,이용아님) 저장하기
+                defaults.set(true, forKey: "isRidingNow_\(userID)")
+            }
+
+            // 킥보드 대여했다는 알림 전송 -> MyViewController가 받음
+            NotificationCenter.default.post(name: .ridingStatusChanged, object: nil)
+
+            // 마커시트 닫기
+            self.dismiss(animated: true)
         })
+
         present(alert, animated: true)
     }
+
 }

--- a/KickGo/KickGo/Controller/MyViewController.swift
+++ b/KickGo/KickGo/Controller/MyViewController.swift
@@ -1,6 +1,12 @@
+import Foundation
 import UIKit
 import SnapKit
 import CoreData
+
+// 킥보드 대여할 때 사용자 상태를 이용중으로 바꾸게 알리는 알림
+extension Notification.Name {
+    static let ridingStatusChanged = Notification.Name("ridingStatusChanged")
+}
 
 // 재사용하는 메뉴 행 뷰 클래스
 class MenuRowView: UIControl {
@@ -115,6 +121,15 @@ class MyViewController: UIViewController {
         myScooterRow.addTarget(self, action: #selector(openMyScooters), for: .touchUpInside)
         logoutButton.addTarget(self, action: #selector(logoutTapped), for: .touchUpInside)
         deleteAccountButton.addTarget(self, action: #selector(deleteAccountTapped), for: .touchUpInside)
+        
+        // 사용자가 킥보드 대여했다는 알림 여기로 받음
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(ridingStatusChanged),
+            name: .ridingStatusChanged,
+            object: nil
+        )
+        
     }
     
     // 스크롤뷰
@@ -434,6 +449,16 @@ class MyViewController: UIViewController {
         present(alert, animated: true)
     }
     
+    // 킥보드 이용중/이용중아님 상태 변경 함수
+    @objc private func ridingStatusChanged() {
+        let defaults = UserDefaults.standard
+        if let userID = defaults.string(forKey: "loggedInUserID") {
+            isRidingNow = defaults.bool(forKey: "isRidingNow_\(userID)")
+        }
+
+        updateStatusUI()
+    }
+    
     // viewWillAppear
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
@@ -451,6 +476,12 @@ class MyViewController: UIViewController {
         // 프로필헤더 UI 업데이트(이름, 이메일)
         nameLabel.text = "\(name)님"
         emailLabel.text = email
+        
+        // 계정별로 이용중 상태 불러오기
+        isRidingNow = defaults.bool(forKey: "isRidingNow_\(userID)")
+
+        // 상태카드 UI 반영
+        updateStatusUI()
     }
 
 


### PR DESCRIPTION
### 작업한 내용

> 해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

대여하기 알럿에서 -> 대여하기 선택하면 -> 상태카드 UI 바뀌게하기 
<모델파일의 엔티티 사용X, 유저디폴트의 사용자 이메일만 사용함>

MarkerSheetViewController에서 킥보드 대여했다는 알림을 보내면
MyViewController가 viewWillAppear에서 알림을 받고 UI 업데이트하는 방식

마이탭 뷰컨트롤러에 알림 블럭을 추가함
(킥보드 대여할 때 사용자 상태를 이용중으로 바꾸게 알리는 알림)

```swift 
extension Notification.Name {
    static let ridingStatusChanged = Notification.Name("ridingStatusChanged")
}
```

상태카드도 유저마다 다르게 저장해야되기 때문에 
정은님이 만들어둔 MarkerSheetViewController.swift의 대여알럿부분에서 로그인정보 가져와서 상태저장 하는 블럭 추가함


### 관련 이슈

Closes #74 

### PR 올리기 전 Check List

**Merge 대상 브랜치가 올바른가?** 네

작업한 코드가 에러 없이 잘 동작하는가? 네
