### PR TITLE
[Feat] #83 -  킥보드 대여알럿->대여하기 선택시 반납버튼 표시, 반납하면 숨겨지게 하기

### DIFF
--- a/KickGo/KickGo/Controller/MapViewController.swift
+++ b/KickGo/KickGo/Controller/MapViewController.swift
@@ -3,11 +3,11 @@ import CoreData
 import NMapsMap
 import CoreLocation
 
-final class MapViewController: UIViewController {
+class MapViewController: UIViewController {
     
     private let mapMainView = MapView()
     private let markerManager = MapMarkerManager()
-    private let mapSearchManager = RegisterLocateSettingView() // 지오코딩 담당
+    private let mapSearchManager = RegisterLocateSettingView()
     private let locationnManager = MapCurrentLocation()
     
     // 마커 색상
@@ -26,11 +26,41 @@ final class MapViewController: UIViewController {
         onCoordinateFound()
         setupLocationManager()
         loadRegisterScooters()
+        
+        // 알림수신 블럭!! 이거 있어야 대여하기 누를 때 바로 반영됨
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(ridingStatusChanged),
+            name: .ridingStatusChanged,
+            object: nil
+        )
+
     }
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        updateReturnCardVisibility()
+    }
+    
+    @objc private func ridingStatusChanged() {
+        updateReturnCardVisibility()
+    }
+
+    // 반납버튼(파란색스택) 표시여부 업데이트하는 함수
+    // 대여중이면 표시하고, 대여중아니면 숨긴다.
+    private func updateReturnCardVisibility() {
+        let defaults = UserDefaults.standard
+        if let userID = defaults.string(forKey: "loggedInUserID") {
+            let isRidingNow = defaults.bool(forKey: "isRidingNow_\(userID)")
+            mapMainView.returnContainerView.isHidden = !isRidingNow
+        }
+    }
+    
+    // 현재 이용 상태를 읽어서 반납카드 표시여부 업데이트함
     private func setupSearchAction() {
         mapMainView.mapSearchTextField.addTarget(self, action: #selector(mapLocationSearch), for: .editingDidEndOnExit)
     }
+    
     // 장소 검색 -> 위치 -> 위도, 경도로 변환
     @objc private func mapLocationSearch() {
         guard let query = mapMainView.mapSearchTextField.text, !query.isEmpty else { return }

--- a/KickGo/KickGo/Views/MapView.swift
+++ b/KickGo/KickGo/Views/MapView.swift
@@ -48,6 +48,7 @@ class MapView: UIView {
         // 반납 카드
         returnContainerView.backgroundColor = .systemBlue
         returnContainerView.layer.cornerRadius = 16
+        returnContainerView.isHidden = true  // 기본적으로 숨겨져있는 상태!
         
         timeLabel.text = "0:02"
         timeLabel.font = .boldSystemFont(ofSize: 24)
@@ -121,7 +122,17 @@ class MapView: UIView {
     // 반납하기 눌렀을 때
     @objc func didTapReturnButton() {
         print("반납하기")
-        // 반납하기 창으로 넘어가는 동시에 반납하기 버튼 사라짐 (반납하기 창은 구현 할 예정입니다)
+        // 이용 상태 false 로 변경
+        let defaults = UserDefaults.standard
+        if let userID = defaults.string(forKey: "loggedInUserID") {
+            defaults.set(false, forKey: "isRidingNow_\(userID)")
+        }
+        
+        // 반납버튼 눌렀을 때 숨기기 처리
+        // 지금은 반납버튼을 숨기기로 처리하지만 버튼을 누르면 반납 절차화면 로직이 이부분에 추가될 예정
         returnContainerView.isHidden = true
+
+        // 다른 화면(MyViewController 등)에 알림 보내기
+        NotificationCenter.default.post(name: .ridingStatusChanged, object: nil)
     }
 }


### PR DESCRIPTION
### 작업한 내용

> 해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

대여하기 알럿에서 대여하기를 선택했을 때 이용중인 파란색 스택이 메인화면에 보이도록 하고, 반납하기 버튼을 눌렀을 때는 숨겨지게 만들었습니다. 마이페이지의 킥보드 이용중/이용중아님 도 같이 업데이트되게 해놨습니다.

지금은 반납하기 버튼을 눌렀을 때 바로 숨겨지지만, 
반납과정 화면으로 넘어가게 만들 예정입니다.

MapViewController에서 
화면이 보일 때(viewWillAppear)와 대여 상태 변경 알림을 받을 때(ridingStatusChanged), 둘 다 updateReturnCardVisibility()를 호출함

유저디폴트의 `이용중인지 확인하는 변수_<유저아이디> `값을 읽어서, 이용 중이면 반납 카드(파란색 스택 를 표시하거나 숨기게 함

![스크린샷 2025-10-17 오후 12 36 17](https://github.com/user-attachments/assets/56da6d89-7175-45eb-8cde-12adfd37f9a7)

<br>

### 실행화면
앱에 처음 진입했을 때

<img width="200" height="500" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-10-17 at 12 29 26" src="https://github.com/user-attachments/assets/d6d8ad7e-edce-493c-ba4f-71ac240e1577" />

킥보드 찾아서 대여하기 눌렀을 때

<img width="200" height="500" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-10-17 at 12 29 59" src="https://github.com/user-attachments/assets/9d201665-4900-4721-81e1-00eb1406a5fd" />

대여해서 이용중일때
<img width="200" height="500" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-10-17 at 12 30 37" src="https://github.com/user-attachments/assets/08eb03ac-4f2d-4740-b2e9-dabd166b4e91" /><img width="200" height="500" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-10-17 at 12 30 58" src="https://github.com/user-attachments/assets/bd10f727-50c5-4f81-8e84-70b6df688fbd" />

반납하기 버튼 눌렀을때
<img width="200" height="500" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-10-17 at 12 31 22" src="https://github.com/user-attachments/assets/0bdca390-b7ae-4515-8e6d-a0ff005ffa3f" /><img width="200" height="500" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-10-17 at 12 31 36" src="https://github.com/user-attachments/assets/3750724d-f45f-480a-91ba-e2010d003be5" />




### 관련 이슈

Closes #83

### PR 올리기 전 Check List

**Merge 대상 브랜치가 올바른가?** 네

작업한 코드가 에러 없이 잘 동작하는가? 네
