### PR TITLE
[Feat] #79 - 등록탭에서 다른탭 이동 시 입력 데이터 초기화

### DIFF
--- a/KickGo/KickGo/Cell/RegisterCheckCell.swift
+++ b/KickGo/KickGo/Cell/RegisterCheckCell.swift
@@ -6,32 +6,15 @@ import SnapKit
 class RegisterCheckCell: UITableViewCell {
     
     static let identifier = "RegisterCheckCell"
-    
-    // 모델명
-    let modelLabel: UILabel = {
+
+    let titleLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.systemFont(ofSize: 14)
         label.textColor = .darkGray
         return label
     }()
-    
-    // 시리얼 넘버
-    let serialLabel: UILabel = {
-        let label = UILabel()
-        label.font = UIFont.systemFont(ofSize: 14)
-        label.textColor = .darkGray
-        return label
-    }()
-    // 배터리
-    let batteryLabel: UILabel = {
-        let label = UILabel()
-        label.font = UIFont.systemFont(ofSize: 14)
-        label.textColor = .darkGray
-        return label
-    }()
-    
-    // 배치 위치
-    let positionLabel: UILabel = {
+
+    let valueLabel: UILabel = {
         let label = UILabel()
         label.font = UIFont.systemFont(ofSize: 14)
         label.textColor = .darkGray
@@ -49,34 +32,25 @@ class RegisterCheckCell: UITableViewCell {
     }
     
     func configureUI(){
-        [modelLabel,serialLabel,batteryLabel,positionLabel].forEach{
+        [titleLabel,valueLabel].forEach{
             contentView.addSubview($0)
         }
     }
     
     func setupLayout(){
-        modelLabel.snp.makeConstraints {
+        titleLabel.snp.makeConstraints {
             $0.leading.equalToSuperview().inset(20)
             $0.centerY.equalToSuperview()
         }
         
-        serialLabel.snp.makeConstraints {
+        valueLabel.snp.makeConstraints {
             $0.trailing.equalToSuperview().inset(20)
             $0.centerY.equalToSuperview()
-        }
-        batteryLabel.snp.makeConstraints {
-            $0.trailing.equalToSuperview().inset(20)
-            $0.centerY.equalToSuperview()
-        }
-        positionLabel.snp.makeConstraints {
-            $0.leading.trailing.equalTo(modelLabel)
-            $0.bottom.equalToSuperview()
-            $0.height.equalTo(1)
         }
     }
     
     public func configure(title: String, value: String) {
-        modelLabel.text = title
-        serialLabel.text = value
+        titleLabel.text = title
+        valueLabel.text = value
     }
 }

--- a/KickGo/KickGo/Controller/MainViewController.swift
+++ b/KickGo/KickGo/Controller/MainViewController.swift
@@ -1,14 +1,16 @@
 import UIKit
 import SnapKit
 
-class MainViewController: UITabBarController {
+class MainViewController: UITabBarController,UITabBarControllerDelegate {
 
     override func viewDidLoad() {
         super.viewDidLoad()
         //상단 back버튼 숨김처리
         self.navigationItem.hidesBackButton = true
+        self.delegate = self
         setupTabs()
         setupTabBarAppearance()
+        
     }
 
     func setupTabs() {
@@ -16,18 +18,21 @@ class MainViewController: UITabBarController {
         let registerVC = UINavigationController(rootViewController: RegisterViewController())
         let myVC = UINavigationController(rootViewController: MyViewController())
 
+        // selectedIndex == 0
         mapVC.tabBarItem = UITabBarItem(
             title: "지도",
             image: UIImage(systemName: "map"),
             selectedImage: UIImage(systemName: "map.fill")
         )
-
+        
+        // selectedIndex == 1
         registerVC.tabBarItem = UITabBarItem(
             title: "등록",
             image: UIImage(systemName: "plus.circle"),
             selectedImage: UIImage(systemName: "plus.circle.fill")
         )
 
+        // selectedIndex == 2
         myVC.tabBarItem = UITabBarItem(
             title: "마이",
             image: UIImage(systemName: "person"),
@@ -41,6 +46,16 @@ class MainViewController: UITabBarController {
         tabBar.tintColor = UIColor(red: 0.145, green: 0.388, blue: 0.922, alpha: 1.0) //#2563EB 컬러
         tabBar.unselectedItemTintColor = UIColor.gray
         tabBar.backgroundColor = .systemBackground
+    }
+    
+    func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController) {
+        if tabBarController.selectedIndex != 1{
+            print("등록탭이 아닌 탭")
+            //등록탭에서 다른 곳으로 이동할 때 실제 사용중인 인스턴스에 접근하기
+            guard let registerTab = self.viewControllers?[1]  as? UINavigationController else { return }
+            guard let registerVC = registerTab.viewControllers.first as? RegisterViewController else { return }
+            registerVC.resetRegistrationForm()
+        }
     }
 }
 

--- a/KickGo/KickGo/Controller/MapViewController.swift
+++ b/KickGo/KickGo/Controller/MapViewController.swift
@@ -21,12 +21,13 @@ final class MapViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         title = "지도"
-        
+
         setupSearchAction()
         onCoordinateFound()
         setupLocationManager()
         loadRegisterScooters()
     }
+ 
     
     private func setupSearchAction() {
         mapMainView.mapSearchTextField.addTarget(self, action: #selector(mapLocationSearch), for: .editingDidEndOnExit)

--- a/KickGo/KickGo/Controller/MyRegisterListViewController.swift
+++ b/KickGo/KickGo/Controller/MyRegisterListViewController.swift
@@ -13,6 +13,9 @@ class MyRegisterListViewController: UIViewController, UITableViewDataSource {
         hideKeyboardWhenTappedAround()
         setupTableView()
         fetchScooters()
+        
+        
+        
     }
 
     private func setupTableView() {

--- a/KickGo/KickGo/Controller/MyViewController.swift
+++ b/KickGo/KickGo/Controller/MyViewController.swift
@@ -115,7 +115,10 @@ class MyViewController: UIViewController {
         myScooterRow.addTarget(self, action: #selector(openMyScooters), for: .touchUpInside)
         logoutButton.addTarget(self, action: #selector(logoutTapped), for: .touchUpInside)
         deleteAccountButton.addTarget(self, action: #selector(deleteAccountTapped), for: .touchUpInside)
+        
+        
     }
+
     
     // 스크롤뷰
     private func setupScrollView() {
@@ -451,6 +454,8 @@ class MyViewController: UIViewController {
         // 프로필헤더 UI 업데이트(이름, 이메일)
         nameLabel.text = "\(name)님"
         emailLabel.text = email
+        
+        
     }
 
 

--- a/KickGo/KickGo/Controller/RegisterViewController.swift
+++ b/KickGo/KickGo/Controller/RegisterViewController.swift
@@ -2,12 +2,15 @@ import UIKit
 import SnapKit
 import CoreData
 
-class RegisterViewController: UIViewController,RegisterCheckDelegate {
+class RegisterViewController: UIViewController,RegisterCheckDelegate{
+
+    
+
     func registerCheckDidTapNext() -> [(title: String, value: String)] {
         return[
             ("모델명", registerView.modelNameTextField.text ?? ""),
             ("시리얼 번호", registerView.serialNumberTextField.text ?? ""),
-            ("배터리", registerView.batteryTextField.text ?? ""),
+            ("배터리", registerView.batteryTextField.text.map { "\($0) %" } ?? ""),
             ("배치 위치", registerLocationSettingView.searchTextField.text ?? "")
         ]
     }
@@ -28,6 +31,7 @@ class RegisterViewController: UIViewController,RegisterCheckDelegate {
         buttonTapped()
         setupViewActions()
     }
+    
     // 초기 뷰 셋팅
     func settingView() {
         registerView.isHidden = false
@@ -152,7 +156,7 @@ class RegisterViewController: UIViewController,RegisterCheckDelegate {
         present(alert, animated: true)
     }
     //등록 화면 데이터 초기화
-    private func resetRegistrationForm() {
+    func resetRegistrationForm() {
         
         registerView.modelNameTextField.text = nil
         registerView.serialNumberTextField.text = nil

--- a/KickGo/KickGo/Views/RegisterCheck.swift
+++ b/KickGo/KickGo/Views/RegisterCheck.swift
@@ -9,7 +9,7 @@ protocol RegisterCheckDelegate: AnyObject {
 
 class RegisterCheck: UIView, UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return infoDummyData.count
+        return infoDatas.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -17,13 +17,13 @@ class RegisterCheck: UIView, UITableViewDelegate, UITableViewDataSource {
             return UITableViewCell()
         }
         cell.selectionStyle = .none
-        let item = infoDummyData[indexPath.row]
+        let item = infoDatas[indexPath.row]
         cell.configure(title: item.title, value: item.value)
         return cell
     }
     
     weak var delegate: RegisterCheckDelegate?
-    var infoDummyData: [(title: String, value: String)] = []
+    var infoDatas: [(title: String, value: String)] = []
     
     //상단 숫자
     let numsLabel: UILabel = {
@@ -217,7 +217,7 @@ class RegisterCheck: UIView, UITableViewDelegate, UITableViewDataSource {
     }
     
     func reloadData(){
-        self.infoDummyData = delegate?.registerCheckDidTapNext() ?? []
+        self.infoDatas = delegate?.registerCheckDidTapNext() ?? []
         self.infoTableView.reloadData()
     }
 }

--- a/KickGo/KickGo/Views/RegisterView.swift
+++ b/KickGo/KickGo/Views/RegisterView.swift
@@ -4,7 +4,6 @@ import UIKit
 import SnapKit
 
 class RegisterView: UIView {
-    
     //상단 숫자
     let numsLabel: UILabel = {
         let label = UILabel()
@@ -196,15 +195,12 @@ class RegisterView: UIView {
     
     //bottomContainerView 하위 요소 오토레이아웃 설정
     func bottomContainerSetUpLayout() {
-        
         // 다음 버튼
         nextButton.snp.makeConstraints {
             $0.height.equalTo(60)
             $0.centerY.equalToSuperview()
             $0.leading.trailing.equalToSuperview().inset(20)
             $0.trailing.equalToSuperview().inset(20)
-            
-            
         }
     }
     
@@ -219,7 +215,7 @@ class RegisterView: UIView {
         nextButton.isEnabled = false
         nextButton.backgroundColor = ColorE5E7EB
     }
-    
+    //delegate로 상태 전달
     @objc func textFieldsChanged() {
         let batteryText = batteryTextField.text ?? ""
         // 세 칸 모두 입력되어야 활성화
@@ -279,4 +275,6 @@ class RegisterView: UIView {
             }
         }
     }
+    
+
 }


### PR DESCRIPTION
### 작업한 내용

> 해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

등록탭 RigisterCheck 테이블 뷰 배터리 (%) 표시 추가
RegisterCheckCell 리팩토링
<img width="220" height="520" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-10-17 at 13 01 10" src="https://github.com/user-attachments/assets/d8e2a09f-8519-4201-abd6-447ee4022f9e" />

등록탭에서 등록 입력 중 다른 탭으로 이동했을 때 기록된 데이터 초기화

탭 전환 이벤트를 감지하기 위해 MainViewController에 UITabBarControllerDelegate 프로토콜을 채택 
<img width="657" height="227" alt="스크린샷 2025-10-17 오후 12 55 02" src="https://github.com/user-attachments/assets/8b6f4ef7-baf7-44c5-9522-fc2846fb8120" />

tabBarController(_:didSelect:) 델리게이트 메서드로 탭이 선택될 때마다 특정 로직을 수행.

현재 사용하고자 하는 등록탭은 selectedIndex가 1이기 때문에, 1이 아닌 경우에만 초기화 진행
<img width="419" height="207" alt="스크린샷 2025-10-17 오후 12 56 03" src="https://github.com/user-attachments/assets/cd0ab800-f60a-4647-9103-cbe1f4fbc519" />

self.viewControllers 배열에 접근하여 현재 탭 바에서 실제 사용 중인 RegisterViewController의 인스턴스를 찾아오도록 구현
resetRegistrationForm() 메서드를 호출하여 모든 입력 필드와 뷰 상태를 초기화.
` //틀린 코드 
let newRegisterVC = RegisterViewController()
newRegisterVC.resetRegistrationForm()`
<img width="960" height="201" alt="스크린샷 2025-10-17 오후 12 59 43" src="https://github.com/user-attachments/assets/088a9332-2e7e-4634-b821-dd8d687db8dd" />

![Adobe Express - 화면 기록 2025-10-17 오후 12 50 12](https://github.com/user-attachments/assets/773f2c5a-4f63-4f30-981d-5ba7f032aac5)

### 관련 이슈

Closes #79 

### PR 올리기 전 Check List

**Merge 대상 브랜치가 올바른가?** 네

작업한 코드가 에러 없이 잘 동작하는가? 네
