### PR TITLE
Feat/#82 반납하기 창 구현하기

### DIFF
--- a/KickGo/KickGo/Controller/MapViewController.swift
+++ b/KickGo/KickGo/Controller/MapViewController.swift
@@ -3,13 +3,19 @@ import CoreData
 import NMapsMap
 import CoreLocation
 
-final class MapViewController: UIViewController {
+final class MapViewController: UIViewController, MapViewDelegate {
+    
+    func mapViewDidTapReturnButton(_ mapView: MapView) {
+        let rentVC = RentViewController()
+        rentVC.modalPresentationStyle = .fullScreen
+        self.present(rentVC, animated: true, completion: nil)
+    }
+    
     
     private let mapMainView = MapView()
     private let markerManager = MapMarkerManager()
     private let mapSearchManager = RegisterLocateSettingView() // 지오코딩 담당
     private let locationnManager = MapCurrentLocation()
-    
     // 마커 색상
     private let markerGray = Color9CA3AF  // 배터리 부족
     private let markerGreen  = Color10B981  // 대여 가능
@@ -21,6 +27,8 @@ final class MapViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         title = "지도"
+        
+        mapMainView.delegate = self
         
         setupSearchAction()
         onCoordinateFound()

--- a/KickGo/KickGo/Controller/MapViewController.swift
+++ b/KickGo/KickGo/Controller/MapViewController.swift
@@ -4,7 +4,7 @@ import NMapsMap
 import CoreLocation
 
 final class MapViewController: UIViewController, MapViewDelegate {
-    
+    // 반납하기 누르면 rentViewController로 넘어가게
     func mapViewDidTapReturnButton(_ mapView: MapView) {
         let rentVC = RentViewController()
         rentVC.modalPresentationStyle = .fullScreen
@@ -137,6 +137,7 @@ final class MapViewController: UIViewController, MapViewDelegate {
 }
 
 extension MapViewController {
+    
     // 마커 누르면 시트 띄우기
     func presentMarkerSheet() {
         let sheetVC = MarkerSheetViewController()

--- a/KickGo/KickGo/Controller/RentViewController.swift
+++ b/KickGo/KickGo/Controller/RentViewController.swift
@@ -1,0 +1,165 @@
+import UIKit
+import CoreLocation
+import NMapsMap
+import SnapKit
+
+class RentViewController: UIViewController {
+    private let titleLabel = UILabel()
+    private let backButton = UIButton()
+    
+    private let returnInfo = UIView()
+    private let scooterLabel = UILabel()
+    private let timeLabel = UILabel()
+    private let priceLabel = UILabel()
+    
+    private let sectionTitleLabel = UILabel()
+    private let returnMap = UIImageView()
+    
+    private let currentLocationButton = UIButton()
+    private let addressButton = UIButton()
+    
+    private let returnCompletedButton = UIButton()
+    
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .white
+        
+        configureUI()
+        setConstraints()
+        
+    }
+    
+    func configureUI() {
+        // 상단
+        backButton.setImage(UIImage(systemName: "chevron.left"), for: .normal)
+        backButton.tintColor = .black
+        backButton.addTarget(self, action: #selector(didTapBackButton), for: .touchUpInside)
+        
+        titleLabel.text = "킥보드 반납"
+        timeLabel.font = .boldSystemFont(ofSize: 18)
+
+        // 정보 카드 뷰
+        returnInfo.backgroundColor = UIColor(red: 239/255, green: 246/255, blue: 255/255, alpha: 1)
+        returnInfo.layer.cornerRadius = 16
+        
+        scooterLabel.text = "KickGo Pro(LG001)"
+        scooterLabel.font = .boldSystemFont(ofSize: 16)
+        scooterLabel.textColor = Color2563EB
+    
+        timeLabel.text = "이용 시간: 30분 47초"
+        timeLabel.font = .boldSystemFont(ofSize: 16)
+        timeLabel.textColor = Color2563EB
+        
+        priceLabel.text = "요금: 1,500원"
+        priceLabel.font = .boldSystemFont(ofSize: 16)
+        priceLabel.textColor = Color2563EB
+        
+        sectionTitleLabel.text = "반납 위치 선택"
+        sectionTitleLabel.font = .boldSystemFont(ofSize: 16)
+        
+        // 지도
+        returnMap.backgroundColor = .gray
+        returnMap.layer.cornerRadius = 8
+        
+        // 위치 선택 버튼
+        currentLocationButton.setTitle("현재 위치로 반납", for: .normal)
+        currentLocationButton.titleLabel?.font = .systemFont(ofSize: 15, weight: .bold)
+        currentLocationButton.setTitleColor(.gray, for: .normal)
+        currentLocationButton.layer.cornerRadius = 12
+        currentLocationButton.layer.borderWidth = 1
+        currentLocationButton.layer.borderColor = UIColor.lightGray.cgColor
+        
+        // 반납 완료 버튼
+        returnCompletedButton.setTitle("반납 완료", for: .normal)
+        returnCompletedButton.setTitleColor(.white, for: .normal)
+        returnCompletedButton.backgroundColor = Color2563EB
+        returnCompletedButton.layer.cornerRadius = 12
+        returnCompletedButton.titleLabel?.font = .boldSystemFont(ofSize: 18)
+        returnCompletedButton.addTarget(self, action: #selector(didTapComplete), for: .touchUpInside)
+        
+        [backButton, titleLabel, returnInfo, sectionTitleLabel, returnMap, currentLocationButton, addressButton, returnCompletedButton].forEach {
+            view.addSubview($0)
+        }
+        [scooterLabel, timeLabel, priceLabel].forEach {
+            returnInfo.addSubview($0)
+        }
+        
+    }
+    
+    func setConstraints() {
+        backButton.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide).offset(10)
+            $0.leading.equalToSuperview().inset(16)
+            $0.size.equalTo(30)
+        }
+
+        titleLabel.snp.makeConstraints {
+            $0.centerY.equalTo(backButton)
+             $0.leading.equalTo(backButton.snp.trailing).offset(10)
+        }
+
+        returnInfo.snp.makeConstraints {
+            $0.top.equalTo(backButton.snp.bottom).offset(22)
+            $0.leading.trailing.equalToSuperview().inset(16)
+            $0.height.equalTo(100)
+        }
+
+        scooterLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(12)
+            $0.leading.equalToSuperview().inset(12)
+        }
+        
+        timeLabel.snp.makeConstraints {
+            $0.top.equalTo(scooterLabel.snp.bottom).offset(8)
+            $0.leading.equalTo(scooterLabel)
+        }
+        
+        priceLabel.snp.makeConstraints {
+            $0.top.equalTo(timeLabel.snp.bottom).offset(8)
+            $0.leading.equalTo(scooterLabel)
+        }
+        
+        sectionTitleLabel.snp.makeConstraints {
+            $0.top.equalTo(returnInfo.snp.bottom).offset(22) // returnInfo 카드 아래에 위치
+            $0.leading.equalTo(returnInfo) // returnInfo와 같은 선상에 위치
+        }
+        
+        // 6. returnMap (지도 - sectionTitleLabel 기준)
+        returnMap.snp.makeConstraints {
+            $0.top.equalTo(sectionTitleLabel.snp.bottom).offset(14) // 타이틀 아래에 위치
+            $0.leading.trailing.equalTo(returnInfo) // returnInfo와 동일한 좌우 여백 사용
+            $0.height.equalTo(256)
+        }
+
+        currentLocationButton.snp.makeConstraints {
+            $0.top.equalTo(returnMap.snp.bottom).offset(16)
+            $0.leading.trailing.equalTo(returnInfo)
+            $0.height.equalTo(60)
+        }
+
+        addressButton.snp.makeConstraints {
+            $0.top.equalTo(currentLocationButton.snp.bottom).offset(8)
+            $0.leading.trailing.equalTo(returnInfo)
+            $0.height.equalTo(50)
+        }
+
+        returnCompletedButton.snp.makeConstraints {
+            $0.top.equalTo(addressButton.snp.bottom).offset(32)
+            $0.leading.trailing.equalTo(returnInfo)
+            $0.height.equalTo(55)
+        }
+    }
+    
+    @objc func didTapBackButton() {
+        dismiss(animated: true)
+    }
+    
+    @objc func didTapComplete() {
+        let alert = UIAlertController(title: nil, message: "킥보드가 성공적으로 반납되었습니다.", preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "확인", style: .default) { [weak self] _ in
+            self?.dismiss(animated: true, completion: nil)
+        })
+        present(alert, animated: true)
+    }
+}

--- a/KickGo/KickGo/Controller/RentViewController.swift
+++ b/KickGo/KickGo/Controller/RentViewController.swift
@@ -3,7 +3,9 @@ import CoreLocation
 import NMapsMap
 import SnapKit
 
-class RentViewController: UIViewController {
+class RentViewController: UIViewController, CLLocationManagerDelegate {
+    var mapView: MapView?
+    
     private let titleLabel = UILabel()
     private let backButton = UIButton()
     
@@ -13,13 +15,11 @@ class RentViewController: UIViewController {
     private let priceLabel = UILabel()
     
     private let sectionTitleLabel = UILabel()
-    private let returnMap = UIImageView()
+    private let returnMap = NMFNaverMapView()
     
     private let currentLocationButton = UIButton()
-    private let addressButton = UIButton()
-    
     private let returnCompletedButton = UIButton()
-    
+    private let locationManager = CLLocationManager()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -27,7 +27,7 @@ class RentViewController: UIViewController {
         
         configureUI()
         setConstraints()
-        
+        setupLocationManager()
     }
     
     func configureUI() {
@@ -39,7 +39,7 @@ class RentViewController: UIViewController {
         titleLabel.text = "킥보드 반납"
         timeLabel.font = .boldSystemFont(ofSize: 18)
 
-        // 정보 카드 뷰
+        // 정보 카드
         returnInfo.backgroundColor = UIColor(red: 239/255, green: 246/255, blue: 255/255, alpha: 1)
         returnInfo.layer.cornerRadius = 16
         
@@ -59,16 +59,18 @@ class RentViewController: UIViewController {
         sectionTitleLabel.font = .boldSystemFont(ofSize: 16)
         
         // 지도
-        returnMap.backgroundColor = .gray
-        returnMap.layer.cornerRadius = 8
+//        returnMap.showLocationButton = true
+        returnMap.mapView.positionMode = .disabled
+//        returnMap.mapView.locationOverlay.hidden = true  // 파란 점 숨기기
         
-        // 위치 선택 버튼
+        // 현재 위치 버튼
         currentLocationButton.setTitle("현재 위치로 반납", for: .normal)
         currentLocationButton.titleLabel?.font = .systemFont(ofSize: 15, weight: .bold)
         currentLocationButton.setTitleColor(.gray, for: .normal)
         currentLocationButton.layer.cornerRadius = 12
         currentLocationButton.layer.borderWidth = 1
         currentLocationButton.layer.borderColor = UIColor.lightGray.cgColor
+        currentLocationButton.addTarget(self, action: #selector(didTapCurrentLocationButton), for: .touchUpInside)
         
         // 반납 완료 버튼
         returnCompletedButton.setTitle("반납 완료", for: .normal)
@@ -78,13 +80,12 @@ class RentViewController: UIViewController {
         returnCompletedButton.titleLabel?.font = .boldSystemFont(ofSize: 18)
         returnCompletedButton.addTarget(self, action: #selector(didTapComplete), for: .touchUpInside)
         
-        [backButton, titleLabel, returnInfo, sectionTitleLabel, returnMap, currentLocationButton, addressButton, returnCompletedButton].forEach {
+        [backButton, titleLabel, returnInfo, sectionTitleLabel, returnMap, currentLocationButton, returnCompletedButton].forEach {
             view.addSubview($0)
         }
         [scooterLabel, timeLabel, priceLabel].forEach {
             returnInfo.addSubview($0)
         }
-        
     }
     
     func setConstraints() {
@@ -96,7 +97,7 @@ class RentViewController: UIViewController {
 
         titleLabel.snp.makeConstraints {
             $0.centerY.equalTo(backButton)
-             $0.leading.equalTo(backButton.snp.trailing).offset(10)
+            $0.leading.equalTo(backButton.snp.trailing).offset(10)
         }
 
         returnInfo.snp.makeConstraints {
@@ -121,14 +122,13 @@ class RentViewController: UIViewController {
         }
         
         sectionTitleLabel.snp.makeConstraints {
-            $0.top.equalTo(returnInfo.snp.bottom).offset(22) // returnInfo 카드 아래에 위치
-            $0.leading.equalTo(returnInfo) // returnInfo와 같은 선상에 위치
+            $0.top.equalTo(returnInfo.snp.bottom).offset(22)
+            $0.leading.equalTo(returnInfo)
         }
         
-        // 6. returnMap (지도 - sectionTitleLabel 기준)
         returnMap.snp.makeConstraints {
-            $0.top.equalTo(sectionTitleLabel.snp.bottom).offset(14) // 타이틀 아래에 위치
-            $0.leading.trailing.equalTo(returnInfo) // returnInfo와 동일한 좌우 여백 사용
+            $0.top.equalTo(sectionTitleLabel.snp.bottom).offset(14)
+            $0.leading.trailing.equalTo(returnInfo)
             $0.height.equalTo(256)
         }
 
@@ -138,27 +138,65 @@ class RentViewController: UIViewController {
             $0.height.equalTo(60)
         }
 
-        addressButton.snp.makeConstraints {
-            $0.top.equalTo(currentLocationButton.snp.bottom).offset(8)
-            $0.leading.trailing.equalTo(returnInfo)
-            $0.height.equalTo(50)
-        }
-
         returnCompletedButton.snp.makeConstraints {
-            $0.top.equalTo(addressButton.snp.bottom).offset(32)
+            $0.top.equalTo(currentLocationButton.snp.bottom).offset(64)
             $0.leading.trailing.equalTo(returnInfo)
             $0.height.equalTo(55)
         }
+    }
+    
+    // 위치 설정
+    private func setupLocationManager() {
+        locationManager.delegate = self
+        locationManager.requestWhenInUseAuthorization()
+        locationManager.startUpdatingLocation()
     }
     
     @objc func didTapBackButton() {
         dismiss(animated: true)
     }
     
+    // 현재 위치 버튼 동작
+    @objc func didTapCurrentLocationButton() {
+        currentLocationButton.layer.borderWidth = 2
+        currentLocationButton.layer.borderColor = Color2563EB.cgColor
+        currentLocationButton.backgroundColor = UIColor(red: 239/255, green: 246/255, blue: 255/255, alpha: 1)
+        currentLocationButton.setTitleColor(Color2563EB, for: .normal)
+        
+        // 현재 위치 가져오기
+        guard let location = locationManager.location else {
+            print("현재 위치 정보를 가져올 수 없습니다.")
+            return
+        }
+        let lat = location.coordinate.latitude
+        let lng = location.coordinate.longitude
+        let cameraUpdate = NMFCameraUpdate(scrollTo: NMGLatLng(lat: lat, lng: lng))
+        cameraUpdate.animation = .fly
+        cameraUpdate.animationDuration = 1.0
+        returnMap.mapView.moveCamera(cameraUpdate)
+        
+        // 마커 표시
+        func returnMarker(lat: Double, lng: Double) {
+            // 마커 표시
+            let marker = NMFMarker(position:NMGLatLng(lat: lat, lng: lng))
+            marker.iconImage = NMF_MARKER_IMAGE_RED
+            if let sym = UIImage(systemName: "mappin.and.ellipse") {
+                marker.iconImage = NMFOverlayImage(image: sym)
+            } else {
+                marker.iconImage = NMF_MARKER_IMAGE_BLACK
+            }
+            marker.mapView = returnMap.mapView
+        }
+        returnMarker(lat: lat, lng: lng)
+    }
+    
+    // 반납 완료 버튼 누르면
     @objc func didTapComplete() {
         let alert = UIAlertController(title: nil, message: "킥보드가 성공적으로 반납되었습니다.", preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "확인", style: .default) { [weak self] _ in
-            self?.dismiss(animated: true, completion: nil)
+            guard let self = self else { return }
+            print("반납 완료")
+            self.dismiss(animated: true)
         })
         present(alert, animated: true)
     }

--- a/KickGo/KickGo/Views/MapView.swift
+++ b/KickGo/KickGo/Views/MapView.swift
@@ -2,12 +2,17 @@ import UIKit
 import SnapKit
 import NMapsMap
 
+protocol MapViewDelegate: AnyObject {
+    func mapViewDidTapReturnButton(_ mapView: MapView)
+}
+
 class MapView: UIView {
     
     let mapView = NMFNaverMapView()
     let mapSearchTextField = UITextField()
     let mapSearchImageView = UIImageView(image: UIImage(systemName: "magnifyingglass"))
     private let iconContainer = UIView(frame: CGRect(x: 0, y: 0, width: 40, height: 24))
+    weak var delegate: MapViewDelegate?
     
     // 반납 카드
     let returnContainerView = UIView()
@@ -120,8 +125,6 @@ class MapView: UIView {
     
     // 반납하기 눌렀을 때
     @objc func didTapReturnButton() {
-        print("반납하기")
-        // 반납하기 창으로 넘어가는 동시에 반납하기 버튼 사라짐 (반납하기 창은 구현 할 예정입니다)
-        returnContainerView.isHidden = true
+        delegate?.mapViewDidTapReturnButton(self)
     }
 }


### PR DESCRIPTION
### 작업한 내용

> 해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

반납하기 화면을 구현했습니다.

흐름: `반납하기` 버튼 클릭-> 반납하기 화면으로 이동 -> `현재 위치로 반납` 클릭-> 현재 위치로 이동 및 마커 표시 (서울 위도, 경도 사용) -> `반납 완료` 클릭 -> 반납 완료 Alert 띄우기

해당 킥보드 이름 데이터 가져오는 것은 지도탭에서 대여하기를 누르고 반납하기 카드 뷰 나타낼 때 연동시킨 후 이 데이터와 또 연동해야할 것 같아 `대여하기 -> 카드 뷰에 킥보드 이름 데이터 연동` 작업을 마친 후 추가하겠습니다.

그리고 반납 완료 누르면 지도탭에서 반납하기 카드 뷰 사라지게하는 것은 서연님께서 구현해주셨기 때문에 코드를 합치면 해결될 것 같습니다.

### 실행 화면
![Simulator Screen Recording - iPhone 16 Pro - 2025-10-17 at 15 00 54](https://github.com/user-attachments/assets/cfdd1a70-c5f5-47e3-adec-9a3b037d1036)

### 관련 이슈

Closes #82 

### PR 올리기 전 Check List

**Merge 대상 브랜치가 올바른가?** 네

작업한 코드가 에러 없이 잘 동작하는가? 네