### PR TITLE
[Feat] #73 - 킥보드 데이터와 동일하게 시트 정보 띄우기

### DIFF
--- a/KickGo/KickGo/Controller/MapViewController.swift
+++ b/KickGo/KickGo/Controller/MapViewController.swift
@@ -150,11 +150,20 @@ class MapViewController: UIViewController, MapViewDelegate {
                     // 마커 추가 작업은 메인 스레드에서
                     DispatchQueue.main.async {
                         self.markerManager.addMarker(
-                            to: self.mapMainView.mapView.mapView ?? NMFMapView(),
+                            to: self.mapMainView.mapView.mapView,
+                            scooter: s,
                             lat: coordinate.latitude,
                             lng: coordinate.longitude,
-                            color: markerColor) {
-                                self.presentMarkerSheet()
+                            color: markerColor) { ScooterEntity in
+                                // 정보 받은 토대로 시트 띄우기
+                                let sheet = MarkerSheetViewController()
+                                sheet.modalPresentationStyle = .pageSheet
+                                sheet.scooter = ScooterEntity
+                                
+                                if let sheetController = sheet.sheetPresentationController {
+                                    sheetController.detents = [.medium()]  // 시트는 중간 높이까지만
+                                }
+                                self.present(sheet, animated: true)
                             }
                     }
                 }

--- a/KickGo/KickGo/Controller/MarkerSheetViewController.swift
+++ b/KickGo/KickGo/Controller/MarkerSheetViewController.swift
@@ -15,6 +15,8 @@ class MarkerSheetViewController: UIViewController {
     
     private let closeButton = UIButton(type: .system)
     
+    var scooter: ScooterEntity?
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         configureUI()
@@ -33,7 +35,7 @@ class MarkerSheetViewController: UIViewController {
         
         
         // 킥보드 이름
-        titleLabel.text = "KickGo Pro"
+        titleLabel.text = scooter?.modelName ?? "KickGo Pro"
         titleLabel.font = .systemFont(ofSize: 20, weight: .bold)
         
         // 상태
@@ -42,7 +44,8 @@ class MarkerSheetViewController: UIViewController {
         statusLabel.textColor = UIColor(red: 5/255, green: 150/255, blue: 105/255, alpha: 1)
         
         // 정보 3개 (배터리, 거리, 요금)
-        let battery = makeItem(iconName: "battery.100", iconColor: .systemGreen, valueText: "85%", titleText: "배터리")
+        let batteryPercent = scooter?.battery ?? 100
+        let battery = makeItem(iconName: "battery.100", iconColor: .systemGreen, valueText: "\(batteryPercent)%", titleText: "배터리")
         let distance = makeItem(iconName: "mappin.and.ellipse", iconColor: .systemBlue, valueText: "50m", titleText: "거리")
         let price = makeItem(iconName: "dollarsign.circle", iconColor: .systemOrange, valueText: "100원", titleText: "분당 요금")
         

--- a/KickGo/KickGo/Utils/MapMarkerManager.swift
+++ b/KickGo/KickGo/Utils/MapMarkerManager.swift
@@ -2,8 +2,8 @@ import NMapsMap
 
 class MapMarkerManager {
     
-    func addMarker( to mapView: NMFMapView, lat: Double, lng: Double, color: UIColor, onTap: (() -> Void)? = nil
-    ) {
+    func addMarker( to mapView: NMFMapView, scooter: ScooterEntity, lat: Double, lng: Double, color: UIColor, onTap: ((ScooterEntity) -> Void)? = nil)
+    {
         let marker = NMFMarker()
         
         marker.position = NMGLatLng(lat: lat, lng: lng)
@@ -12,7 +12,8 @@ class MapMarkerManager {
         
         // 마커 눌렀을 때 동작
         marker.touchHandler = { _ in
-            onTap?()
+            onTap?(scooter)  // 클릭 시 해당 킥보드 정보 전달
+            print("\(scooter)")
             print("tap")
             return true
         }


### PR DESCRIPTION
### 작업한 내용

> 해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

마커 클릭 시 나타나는 시트의 정보는 고정되어 있었지만
킥보드 데이터를 가져와 해당 마커 클릭시 시트에 동일한 정보(이름, 배터리)를 띄우는 기능을 구현했습니다.

### 실행 화면
< 지역: 춘천, 킥보드 이름: 2, 배터리: 50 >
<img width="200" height="500" alt="Image" src="https://github.com/user-attachments/assets/25d58d92-fac5-4a25-a4cb-d74c95a66d29" />
<br>
< 춘천에 표시된 마커 클릭 -> 킥보드 이름 + 배터리 등록한 대로 표시 >
<img width="200" height="500" alt="Image" src="https://github.com/user-attachments/assets/1c80f9a9-27de-4ea9-9f58-7de2db4e0eb0" />

### 관련 이슈

Closes #73 

### PR 올리기 전 Check List

**Merge 대상 브랜치가 올바른가?** 네

작업한 코드가 에러 없이 잘 동작하는가? 네
