### PR TITLE
[Refactor] #93 - 등록 탭 코드 클린업

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ playground.xcworkspace
 
 # Environment (환경 변수 파일)
 .env
+
+# API Keys
+APIKey.xcconfig

--- a/KickGo/APIKey.xcconfig.example.xcconfig
+++ b/KickGo/APIKey.xcconfig.example.xcconfig
@@ -1,0 +1,13 @@
+//
+//  APIKey.xcconfig
+//  KickGo
+//
+//  Created by oww on 10/17/25.
+//
+
+// Configuration settings file format documentation can be found at:
+// https://help.apple.com/xcode/#/dev745c5c974
+
+// 이 파일을 복사하여 APIKey.xcconfig 파일을 만들어주세요.
+APIKEYID = oj5l1oliar
+APIKEY = wndlYwoXCHG0cV6r465Jy502IN1rQZV2hslxhwMm

--- a/KickGo/KickGo.xcodeproj/project.pbxproj
+++ b/KickGo/KickGo.xcodeproj/project.pbxproj
@@ -7,11 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		949D0E0A2EA23B0E008B982A /* APIKey.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 949D0E092EA23B0E008B982A /* APIKey.xcconfig */; };
 		FBB1CDF12E9CDF7F007B41DE /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = FBB1CDF02E9CDF7F007B41DE /* SnapKit */; };
 		FBB1CE432E9D12B4007B41DE /* NMapsMap in Frameworks */ = {isa = PBXBuildFile; productRef = FBB1CE422E9D12B4007B41DE /* NMapsMap */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		949D0E092EA23B0E008B982A /* APIKey.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = APIKey.xcconfig; sourceTree = "<group>"; };
 		FBB1CDD72E9CDEAB007B41DE /* KickGo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = KickGo.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -52,6 +54,7 @@
 		FBB1CDCE2E9CDEAB007B41DE = {
 			isa = PBXGroup;
 			children = (
+				949D0E092EA23B0E008B982A /* APIKey.xcconfig */,
 				FBB1CDD92E9CDEAB007B41DE /* KickGo */,
 				FBB1CDD82E9CDEAB007B41DE /* Products */,
 			);
@@ -135,6 +138,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				949D0E0A2EA23B0E008B982A /* APIKey.xcconfig in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -161,6 +165,7 @@
 				DEVELOPMENT_TEAM = JDARSK83RW;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KickGo/Info.plist;
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "사용자의 위치를 받습니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = "";
@@ -194,6 +199,7 @@
 				DEVELOPMENT_TEAM = JDARSK83RW;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = KickGo/Info.plist;
+				INFOPLIST_KEY_NSLocationWhenInUseUsageDescription = "사용자의 위치를 받습니다.";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = "";
@@ -219,6 +225,7 @@
 		};
 		FBB1CDED2E9CDEAC007B41DE /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 949D0E092EA23B0E008B982A /* APIKey.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -282,6 +289,7 @@
 		};
 		FBB1CDEE2E9CDEAC007B41DE /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 949D0E092EA23B0E008B982A /* APIKey.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;

--- a/KickGo/KickGo/Controller/RegisterViewController.swift
+++ b/KickGo/KickGo/Controller/RegisterViewController.swift
@@ -2,10 +2,7 @@ import UIKit
 import SnapKit
 import CoreData
 
-class RegisterViewController: UIViewController,RegisterCheckDelegate{
-
-    
-
+class RegisterViewController: UIViewController,RegisterCheckDelegate,CreateAlert{
     func registerCheckDidTapNext() -> [(title: String, value: String)] {
         return[
             ("모델명", registerView.modelNameTextField.text ?? ""),
@@ -14,8 +11,6 @@ class RegisterViewController: UIViewController,RegisterCheckDelegate{
             ("배치 위치", registerLocationSettingView.searchTextField.text ?? "")
         ]
     }
-    
-    
     let registerView = RegisterView()
     let registerLocationSettingView = RegisterLocateSettingView()
     let registerCheck = RegisterCheck()
@@ -70,34 +65,31 @@ class RegisterViewController: UIViewController,RegisterCheckDelegate{
         registerCheck.finishButton.addTarget(self, action: #selector(saveScooterInfo), for: .touchUpInside)
     }
     
+    //
+    private func showVies(view: UIView){
+        registerView.isHidden = true
+        registerLocationSettingView.isHidden = true
+        registerCheck.isHidden = true
+        
+        view.isHidden = false
+    }
+    
     
     @objc func goNext(){
-        
-        if registerView.isHidden == false{
-            registerView.isHidden = true
-            registerLocationSettingView.isHidden = false
-            registerCheck.isHidden = true
+        if !registerView.isHidden {
+            showVies(view: registerLocationSettingView)
+        } else if !registerLocationSettingView.isHidden{
             registerCheck.reloadData()
-        } else if registerLocationSettingView.isHidden == false{
-            registerView.isHidden = true
-            registerLocationSettingView.isHidden = true
-            registerCheck.isHidden = false
-            registerCheck.reloadData()
-        } else if registerCheck.isHidden == false{
-            //완료 알럿 함수 나타내기
+            showVies(view: registerCheck)
         }
+        
     }
     @objc func goPrev(){
-        if registerLocationSettingView.isHidden == false{
-            registerView.isHidden = false
-            registerLocationSettingView.isHidden = true
-            registerCheck.isHidden = true
-        } else if registerCheck.isHidden == false{
-            registerView.isHidden = true
-            registerLocationSettingView.isHidden = false
-            registerCheck.isHidden = true
+        if !registerLocationSettingView.isHidden {
+            showVies(view: registerView)
+        } else if !registerCheck.isHidden {
+            showVies(view: registerLocationSettingView)
         }
-        
     }
     
     // 킥보드 정보 저장 메서드
@@ -125,7 +117,7 @@ class RegisterViewController: UIViewController,RegisterCheckDelegate{
 
         do {
             try context.save()
-            showAlert(title: "등록 완료", message: "킥보드 정보가 저장되었습니다.")
+            alertShow(title: "등록 완료", message: "킥보드 정보가 저장되었습니다.")
             resetRegistrationForm()
         } catch {
             print("저장 실패: \(error)")
@@ -134,27 +126,33 @@ class RegisterViewController: UIViewController,RegisterCheckDelegate{
     
     // ReigisterView, RegisterLocateSettingView 알람표시
     private func setupViewActions(){
-        registerView.onInvalidBatteryValueEntered = { [weak self] message in
-            self?.showAlert(title: "입력 오류", message: message)
+        /// 비동기 작업 알림 처리
+        /// Controller가 geocodingError의 완료 결과을 받아 직접 알림을 표시하는 구조입니다.
+        registerLocationSettingView.geocodingError = { [weak self] in
+            self?.alertShow(title: "위치 검색 실패", message: RegisterError.searchResultError.message)
         }
-        registerLocationSettingView.geocodingError = { [weak self] message in
-            self?.showAlert(title: "위치 검색 실패", message: message)
-        }
+        registerView.batteryTextField.addTarget(self, action: #selector(battaryChanged), for: .editingChanged)
         
     }
-
-
-
-    // 등록완료 알럿
-    func showAlert(title: String, message: String, completion: (() -> Void)? = nil) {
-        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        
-        let completAction = UIAlertAction(title: "확인", style: .default) { (_) in
-            completion?()
+    @objc private func battaryChanged(){
+        guard let batteryText = registerView.batteryTextField.text, !batteryText.isEmpty,
+              let batteryValue = Int(batteryText) else {
+            return
         }
-        alert.addAction(completAction)
-        present(alert, animated: true)
+        // 100을 초과했을 경우
+        if batteryValue > 100 {
+            registerView.batteryTextField.text = "100"
+            alertShow(title: "입력 오류", message: RegisterError.maxBattaryError.message)
+        }
+        
+        // 1 미만일 경우
+        if batteryValue < 1 {
+            // 값을 0으로 강제 변경하고, 에러 메시지를 enum에서 가져와 알림창을 띄웁니다.
+            registerView.batteryTextField.text = "0"
+            alertShow(title: "입력 오류", message: RegisterError.minBattaryError.message)
+        }
     }
+
     //등록 화면 데이터 초기화
     func resetRegistrationForm() {
         

--- a/KickGo/KickGo/Controller/SignUpVIewController.swift
+++ b/KickGo/KickGo/Controller/SignUpVIewController.swift
@@ -76,6 +76,7 @@ class SignUpVIewController: UIViewController,CreateAlert {
         signUpButton.addTarget(self, action: #selector(completeSignUp), for: .touchUpInside)
         setupTargets()
         setupUI()
+        setupLayout()
         hideKeyboardWhenTappedAround()
         phoneNumsTextField.addTarget(self, action: #selector (phoneTextFieldDidChange), for: .editingChanged)
         // UserDefault 데이터 경로

--- a/KickGo/KickGo/Info.plist
+++ b/KickGo/KickGo/Info.plist
@@ -2,19 +2,21 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>사용자의 위치를 받습니다.</string>
+	<key>APIKEY</key>
+	<string>$(APIKEY)</string>
+	<key>APIKEYID</key>
+	<string>$(APIKEYID)</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSExceptionDomains</key>
 		<dict>
 			<key>naveropenapi.apigw.ntruss.com</key>
 			<dict>
-				<key>NSIncludesSubdomains</key>
-				<true/>
 				<key>NSExceptionAllowsInsecureHTTPLoads</key>
 				<true/>
 				<key>NSExceptionRequiresForwardSecrecy</key>
+				<true/>
+				<key>NSIncludesSubdomains</key>
 				<true/>
 			</dict>
 		</dict>

--- a/KickGo/KickGo/Model/const.swift
+++ b/KickGo/KickGo/Model/const.swift
@@ -1,0 +1,11 @@
+//
+//  const.swift
+//  KickGo
+//
+//  Created by oww on 10/17/25.
+//
+
+import Foundation
+
+let APIKey = Bundle.main.infoDictionary?["APIKEY"] as! String
+let APIKeyID = Bundle.main.infoDictionary?["APIKEYID"] as! String

--- a/KickGo/KickGo/Utils/Error.swift
+++ b/KickGo/KickGo/Utils/Error.swift
@@ -34,3 +34,21 @@ enum SignUpError:Error{
         }
     }
 }
+
+// 등록 에러 타입
+enum RegisterError: Error{
+    case searchResultError
+    case minBattaryError
+    case maxBattaryError
+    
+    var message: String{
+        switch self{
+        case .searchResultError:
+            return "검색 결과를 찾을 수 없습니다."
+        case .minBattaryError:
+            return "배터리 잔량은 0보다 커야 합니다."
+        case .maxBattaryError:
+            return "배터리 잔량은 1~100 사이의 숫자여야 합니다."
+        }
+    }
+}

--- a/KickGo/KickGo/Views/RegisterCheck.swift
+++ b/KickGo/KickGo/Views/RegisterCheck.swift
@@ -3,6 +3,8 @@ import Foundation
 import UIKit
 import SnapKit
 
+/// protocol 채택한 이유
+/// 사용하지 않았다면 RegisterView와 RegisterLocationSettinView에 의존하여 데이터를 가져와야 합니다.
 protocol RegisterCheckDelegate: AnyObject {
     func registerCheckDidTapNext() -> [(title: String, value: String)]
 }

--- a/KickGo/KickGo/Views/RegisterLocateSetting.swift
+++ b/KickGo/KickGo/Views/RegisterLocateSetting.swift
@@ -266,7 +266,7 @@ class RegisterLocateSettingView: UIView {
     var onCoordinateFound: ((Double, Double) -> Void)?
     
     // Geocoding API 호출 및 지도 이동
-    var geocodingError: ((String) -> Void)?
+    var geocodingError: (() -> Void)?
     func geocode(query: String) {
         guard let encodeQuery = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
               let url = URL(string: "https://maps.apigw.ntruss.com/map-geocode/v2/geocode?query=\(encodeQuery)") else { return }
@@ -274,8 +274,8 @@ class RegisterLocateSettingView: UIView {
         var request = URLRequest(url: url)
         request.httpMethod = "GET"
         // 나중에 키값 보안을 위한 리팩토링 진행해야함
-        request.addValue("oj5l1oliar", forHTTPHeaderField: "X-NCP-APIGW-API-KEY-ID")
-        request.addValue("wndlYwoXCHG0cV6r465Jy502IN1rQZV2hslxhwMm", forHTTPHeaderField: "X-NCP-APIGW-API-KEY")
+        request.addValue(APIKeyID, forHTTPHeaderField: "X-NCP-APIGW-API-KEY-ID")
+        request.addValue(APIKey, forHTTPHeaderField: "X-NCP-APIGW-API-KEY")
         request.addValue("application/json", forHTTPHeaderField: "Accept")
         
         URLSession.shared.dataTask(with: request) { [weak self] data, response, error in
@@ -302,7 +302,7 @@ class RegisterLocateSettingView: UIView {
             } catch {
                 //위치 검색 실패시
                 DispatchQueue.main.async {
-                    self?.geocodingError?("검색 결과를 찾을 수 없습니다.")
+                    self?.geocodingError?()
                     //nextButton 비활성화
                     self?.isLocated = false
                     self?.nextButtonState()

--- a/KickGo/KickGo/Views/RegisterView.swift
+++ b/KickGo/KickGo/Views/RegisterView.swift
@@ -222,7 +222,6 @@ class RegisterView: UIView {
         let filled = !(modelNameTextField.text?.isEmpty ?? true) &&
         !(serialNumberTextField.text?.isEmpty ?? true) &&
         !(batteryText.isEmpty) &&
-        //입력 숫자 체크(1~100)
         checkBatteryTextField()
         
         // 버튼 상태 업데이트
@@ -237,44 +236,20 @@ class RegisterView: UIView {
             nextButton.backgroundColor = ColorE5E7EB
             nextButton.setTitleColor(.darkGray, for: .normal)
         }
-        showBatteryError()
     }
     
-    // 배터리 입력된 숫자 1~100체크
-    // 추후 알림 메세지 Error파일 만들어서 리팩토링하기
-    var onInvalidBatteryValueEntered: ((String) -> Void)?
+    // 배터리 입력된 숫자 1~100가 맞는지 체크
+   
+    
     func checkBatteryTextField() -> Bool {
-        
         guard let batteryText = batteryTextField.text,
               let batteryTextFieldValue = Int(batteryText) else {
-            
             return false
         }
-        
         if batteryTextFieldValue < 1 || batteryTextFieldValue > 100 {
             return false
         }
-        
         return true
     }
     
-    func showBatteryError(){
-        // 비어있는 문자열 체크 및 Int로 변환
-        guard let batteryText = batteryTextField.text, !batteryText.isEmpty,
-              let batteryValue = Int(batteryText) else {
-            return
-        }
-        // 1~100 범위를 벗어났을 경우
-        if batteryValue < 1 || batteryValue > 100 {
-            if batteryValue > 100 {
-                batteryTextField.text = "100"
-                onInvalidBatteryValueEntered?("배터리 잔량은 1~100 사이의 숫자여야 합니다.")
-            } else if batteryValue < 1 {
-                batteryTextField.text = "0"
-                onInvalidBatteryValueEntered?("배터리 잔량은 0보다 커야 합니다.")
-            }
-        }
-    }
-    
-
 }


### PR DESCRIPTION
### 작업한 내용

> 해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

코드 컨벤션 및 네이밍 통일

.xcconfig 파일로 API KEY 숨기기
좌측 프로젝트에 APIKey.xcconfig 생성 후 Key값 셋팅
<img width="245" height="144" alt="스크린샷 2025-10-17 오후 5 52 02" src="https://github.com/user-attachments/assets/da1c09b1-ae0d-4012-ae36-4afae418104f" />

프로젝트 Configuratinons에서 해당 파일 추가
<img width="1210" height="270" alt="스크린샷 2025-10-17 오후 6 50 09" src="https://github.com/user-attachments/assets/ca866afb-1798-46e0-9295-dea5138502ef" />

TARGET에서 해당 Key값과 Value 설정
<img width="1210" height="452" alt="image" src="https://github.com/user-attachments/assets/c7c296a6-8c84-4679-9f08-40985b2c9c4a" />

기존 하드코딩으로 처리했던 키 값 처리
<img width="750" height="64" alt="image" src="https://github.com/user-attachments/assets/3a309fc8-15f5-42b2-b01a-db62c5421554" />

원본 파일은 .gitignore로 숨기기
<img width="307" height="70" alt="스크린샷 2025-10-17 오후 6 54 13" src="https://github.com/user-attachments/assets/171e80bb-1096-458a-8b4e-4be3cd0fe206" />

팀원분들이 해주셔야 하는 부분
APIKey.xcconfig.example 을 APIKey.xcconfig로 변경해주시고 APIKey.xcconfig.example 삭제
<img width="768" height="269" alt="스크린샷 2025-10-17 오후 6 55 15" src="https://github.com/user-attachments/assets/4054fe61-344d-46a6-b8b3-c8f5c12bc0ef" />

이미 이전에 계속 키 값이 있는 상태로 커밋을 했기 때문에 프로젝트가 끝나면 네이버 콘솔에서 삭제 부탁드립니다.

### 관련 이슈

Closes #93 

### PR 올리기 전 Check List

**Merge 대상 브랜치가 올바른가?** 네

작업한 코드가 에러 없이 잘 동작하는가? 네
