### PR TITLE
[Feat] #97 - 이용중인 킥보드 마커는 지도에서 표시 제거

### DIFF
--- a/KickGo/KickGo/Controller/MapViewController.swift
+++ b/KickGo/KickGo/Controller/MapViewController.swift
@@ -3,7 +3,13 @@ import CoreData
 import NMapsMap
 import CoreLocation
 
-class MapViewController: UIViewController, MapViewDelegate {
+class MapViewController: UIViewController, MapViewDelegate, MarkerSheetDelegate {
+    // delegate 채택
+    func didRentScooter(_ scooter: ScooterEntity) {
+        markerManager.removeMarker(for: scooter)
+        print("마커 제거 완료")
+    }
+    
     // 반납하기 누르면 rentViewController로 넘어가게
     func mapViewDidTapReturnButton(_ mapView: MapView) {
         let rentVC = RentViewController()
@@ -176,6 +182,7 @@ class MapViewController: UIViewController, MapViewDelegate {
                                 let sheet = MarkerSheetViewController()
                                 sheet.modalPresentationStyle = .pageSheet
                                 sheet.scooter = ScooterEntity
+                                sheet.delegate = self
                                 
                                 if let sheetController = sheet.sheetPresentationController {
                                     sheetController.detents = [.medium()]  // 시트는 중간 높이까지만

--- a/KickGo/KickGo/Controller/MarkerSheetViewController.swift
+++ b/KickGo/KickGo/Controller/MarkerSheetViewController.swift
@@ -1,6 +1,10 @@
 import UIKit
 import SnapKit
 
+protocol MarkerSheetDelegate: AnyObject {
+    func didRentScooter(_ scooter: ScooterEntity)
+}
+
 class MarkerSheetViewController: UIViewController {
     
     private let iconView = UIImageView(image: UIImage(systemName: "bicycle"))
@@ -16,6 +20,7 @@ class MarkerSheetViewController: UIViewController {
     private let closeButton = UIButton(type: .system)
     
     var scooter: ScooterEntity?
+    weak var delegate: MarkerSheetDelegate?
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -184,6 +189,7 @@ extension MarkerSheetViewController {
 
         alert.addAction(UIAlertAction(title: "취소", style: .cancel))
         alert.addAction(UIAlertAction(title: "대여하기", style: .default) { _ in
+            guard let scooter = self.scooter else { return }
             let defaults = UserDefaults.standard
 
             // 현재 로그인한 계정의 아이디 가져오기
@@ -195,6 +201,8 @@ extension MarkerSheetViewController {
             // 킥보드 대여했다는 알림 전송 -> MyViewController가 받음
             NotificationCenter.default.post(name: .ridingStatusChanged, object: nil)
 
+            // 마커 제거 요청
+            self.delegate?.didRentScooter(scooter)
             // 마커시트 닫기
             self.dismiss(animated: true)
         })

--- a/KickGo/KickGo/Utils/MapMarkerManager.swift
+++ b/KickGo/KickGo/Utils/MapMarkerManager.swift
@@ -1,6 +1,8 @@
 import NMapsMap
 
 class MapMarkerManager {
+    // 킥보드 id별 마커 저장
+    private var markers: [String: NMFMarker] = [:]
     
     func addMarker( to mapView: NMFMapView, scooter: ScooterEntity, lat: Double, lng: Double, color: UIColor, onTap: ((ScooterEntity) -> Void)? = nil)
     {
@@ -9,6 +11,11 @@ class MapMarkerManager {
         marker.position = NMGLatLng(lat: lat, lng: lng)
         marker.iconImage = NMFOverlayImage(image: makeMarkerImage(color: color))
         marker.mapView = mapView
+        
+        // ID 기준으로 저장
+        if let id = scooter.ownerID {
+            markers[id] = marker
+        }
         
         // 마커 눌렀을 때 동작
         marker.touchHandler = { _ in
@@ -38,5 +45,12 @@ class MapMarkerManager {
                 symbol.draw(at: CGPoint(x: symbolX, y: symbolY))
             }
         }
+    }
+    
+    // 마커 제거
+    func removeMarker(for scooter: ScooterEntity) {
+        guard let id = scooter.ownerID, let marker = markers[id] else { return }
+        marker.mapView = nil
+        markers.removeValue(forKey: id)
     }
 }


### PR DESCRIPTION
### 작업한 내용

> 해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

해당 마커의 킥보드를 대여하면 해당 마커는 지도에서 사라지는 기능입니다.

마커 제거를 위해 `MarkerSheetDelegate`를 생성했습니다.

![Simulator Screen Recording - iPhone 16 Pro - 2025-10-17 at 20 48 50](https://github.com/user-attachments/assets/c1101ea2-24fe-40a4-a9f4-c1b43bfcde90)

### 관련 이슈

Closes #97

### PR 올리기 전 Check List

**Merge 대상 브랜치가 올바른가?** 네

작업한 코드가 에러 없이 잘 동작하는가? 네
