### PR TITLE
[Design] #108 - 킥보드정보 모달시트 UI 수정

### DIFF
--- a/KickGo/KickGo/Controller/MarkerSheetViewController.swift
+++ b/KickGo/KickGo/Controller/MarkerSheetViewController.swift
@@ -48,17 +48,17 @@ class MarkerSheetViewController: UIViewController {
         statusLabel.font = .systemFont(ofSize: 14, weight: .semibold)
         statusLabel.textColor = UIColor(red: 5/255, green: 150/255, blue: 105/255, alpha: 1)
         
-        // 정보 3개 (배터리, 거리, 요금)
+        // 정보 2개 (배터리, 요금)
         let batteryPercent = scooter?.battery ?? 100
         let battery = makeItem(iconName: "battery.100", iconColor: .systemGreen, valueText: "\(batteryPercent)%", titleText: "배터리")
-        let distance = makeItem(iconName: "mappin.and.ellipse", iconColor: .systemBlue, valueText: "50m", titleText: "거리")
+        //let distance = makeItem(iconName: "mappin.and.ellipse", iconColor: .systemBlue, valueText: "50m", titleText: "거리")
         let price = makeItem(iconName: "dollarsign.circle", iconColor: .systemOrange, valueText: "100원", titleText: "분당 요금")
         
         infoStack.axis = .horizontal
         infoStack.alignment = .center
-        infoStack.distribution = .equalSpacing
-        infoStack.spacing = 24
-        [battery, distance, price].forEach { infoStack.addArrangedSubview($0) }
+        infoStack.distribution = .fillEqually
+        infoStack.spacing = 0
+        [battery,  price].forEach { infoStack.addArrangedSubview($0) }
         
         // 이용 안내 영역
         notiContainer.backgroundColor = UIColor(red: 249/255, green: 250/255, blue: 251/255, alpha: 1)


### PR DESCRIPTION
### 작업한 내용

> 해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

기존: 킥보드마커를 눌렀을 때 킥보드정보 모달시트에서 배터리/거리/분당요금이 표시됨
수정사항: 거리 정보 제거함

<img width="200" height="500" alt="Simulator Screenshot - iPhone 16 Pro Max - 2025-10-20 at 10 38 47" src="https://github.com/user-attachments/assets/3f92a081-73e1-449c-bc81-85f838539c87" />


### 관련 이슈

Closes #108 

### PR 올리기 전 Check List

**Merge 대상 브랜치가 올바른가?** 네

작업한 코드가 에러 없이 잘 동작하는가? 네
