### PR TITLE
[Feat] #109 - 등록과 동시에 지도에 마커 표시

### DIFF
--- a/KickGo/KickGo/Controller/MapViewController.swift
+++ b/KickGo/KickGo/Controller/MapViewController.swift
@@ -52,7 +52,14 @@ class MapViewController: UIViewController, MapViewDelegate, MarkerSheetDelegate 
             name: .ridingStatusChanged,
             object: nil
         )
-
+        
+        //
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleNewScooter),
+            name: NSNotification.Name("NewScooter"),
+            object: nil
+        )
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -80,7 +87,60 @@ class MapViewController: UIViewController, MapViewDelegate, MarkerSheetDelegate 
             }
         }
     }
-
+    
+    @objc private func handleNewScooter(_ notification: Notification) {
+        guard let userInfo = notification.userInfo,
+              let scooter = userInfo["scooter"] as? ScooterEntity else { return }
+        
+        guard let position = scooter.position else { return }
+        let batteryLevel = Int(scooter.battery)
+        
+        let geocoder = CLGeocoder()
+        
+        geocoder.geocodeAddressString(position) { [weak self] locationMarks, error in
+            guard let self = self else { return }
+            
+            let markerColor: UIColor
+            if batteryLevel < 20 {
+                markerColor = UIColor.systemRed
+            } else if batteryLevel < 70 {
+                markerColor = self.markerGray
+            } else {
+                markerColor = self.markerGreen
+            }
+            
+            if let error = error {
+                print("새 킥보드 지오코딩 실패 \(position)")
+                return
+            }
+            guard let coordinate = locationMarks?.first?.location?.coordinate else {
+                print("새 킥보드 좌표 변환 실패 \(position)")
+                return
+            }
+            print("새 킥보드 지오코딩 성공! \(position) 위도: \(coordinate.latitude), 경도: \(coordinate.longitude)")
+            
+            // 마커 추가 작업은 메인 스레드에서
+            DispatchQueue.main.async {
+                self.markerManager.addMarker(
+                    to: self.mapMainView.mapView.mapView,
+                    scooter: scooter,
+                    lat: coordinate.latitude,
+                    lng: coordinate.longitude,
+                    color: markerColor) { ScooterEntity in
+                        // 정보 받은 토대로 시트 띄우기
+                        let sheet = MarkerSheetViewController()
+                        sheet.modalPresentationStyle = .pageSheet
+                        sheet.scooter = ScooterEntity
+                        sheet.delegate = self
+                        
+                        if let sheetController = sheet.sheetPresentationController {
+                            sheetController.detents = [.medium()]  // 시트는 중간 높이까지만
+                        }
+                        self.present(sheet, animated: true)
+                    }
+            }
+        }
+    }
 
     // 반납버튼(파란색스택) 표시여부 업데이트하는 함수
     // 대여중이면 표시하고, 대여중아니면 숨긴다.

--- a/KickGo/KickGo/Controller/RegisterViewController.swift
+++ b/KickGo/KickGo/Controller/RegisterViewController.swift
@@ -118,6 +118,7 @@ class RegisterViewController: UIViewController,RegisterCheckDelegate,CreateAlert
         do {
             try context.save()
             alertShow(title: "등록 완료", message: "킥보드 정보가 저장되었습니다.")
+            NotificationCenter.default.post(name: NSNotification.Name("NewScooter"), object: nil, userInfo: ["scooter": scooter])
             resetRegistrationForm()
         } catch {
             print("저장 실패: \(error)")


### PR DESCRIPTION
### 작업한 내용

> 해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

원래는 등록 -> 재실행을 해야 지도에 마커가 표시되었는데, 
등록 -> 지도탭으로 가면 바로 지도에 마커가 표시되게 구현했습니다!

RegisterViewController에서 MapViewController로 '새 킥보드가 저장되었다'는 알림과 새 킥보드 정보를 전송합니다.
옵저버를 등록해 정보와 알림을 받겠다고 알려줍니다!
그리고 킥보드 정보를 지도에 마커로 추가하는 코드를 활용해 추가할 수 있게 작성했습니다.

![Simulator Screen Recording - iPhone 16 Pro - 2025-10-20 at 10 53 03](https://github.com/user-attachments/assets/d296b41c-447e-49a9-9457-36fcfdf16feb)


### 관련 이슈

Closes #109 

### PR 올리기 전 Check List

**Merge 대상 브랜치가 올바른가?** 네

작업한 코드가 에러 없이 잘 동작하는가? 네