### PR TITLE
[Fix] #112 - 지도탭에서 검색 후 지도 이동

### DIFF
--- a/KickGo/KickGo/Views/RegisterLocateSetting.swift
+++ b/KickGo/KickGo/Views/RegisterLocateSetting.swift
@@ -297,6 +297,8 @@ class RegisterLocateSettingView: UIView {
                         //nextButton 활성화
                         self?.isLocated = true
                         self?.nextButtonState()
+                        // mapVC의 moveCamera 실행시킴!
+                        self?.onCoordinateFound?(lat, lng)
                     }
                 }
             } catch {


### PR DESCRIPTION
### 작업한 내용

> 해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

🚨 지도탭에서 검색 후 위도, 경도 변환은 되지만 지도가 이동하지 않는 오류를 해결했습니다.

❓ mapVC의 `onCoordinatedFound`(RegisterLocateSeetingView가 좌표를 찾으면 moveCamera를 실행하는 부분) 콜백을 호출하는 코드가 누락되어있었음

🛠️ RegisterLocateSettingView의 `func geocode(qurery: )` 내부에 위치 검색 성공 시 **`self?.onCoordinateFound?(lat, lng)`** 를 추가해 MapVC의 moveCamera 함수가 호출되게 연결해주면서 해결 완료!!!

![Simulator Screen Recording - iPhone 16 Pro - 2025-10-20 at 11 52 07](https://github.com/user-attachments/assets/cad0b797-bd81-4e9e-96b0-1b920f44833f)

### 관련 이슈

Closes #112 

### PR 올리기 전 Check List

**Merge 대상 브랜치가 올바른가?** 네

작업한 코드가 에러 없이 잘 동작하는가? 네