### PR TITLE
[Refactor] #116 - 대여중일 때 해당 마커 표시 제거 시 버그 발생

### DIFF
--- a/KickGo/KickGo/Controller/MapViewController.swift
+++ b/KickGo/KickGo/Controller/MapViewController.swift
@@ -53,7 +53,7 @@ class MapViewController: UIViewController, MapViewDelegate, MarkerSheetDelegate 
             object: nil
         )
         
-        //
+        // 이거 있어야 킥보드 등록과 동시에 지도에 마커 표시가 됨!!
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(handleNewScooter),

--- a/KickGo/KickGo/Utils/MapMarkerManager.swift
+++ b/KickGo/KickGo/Utils/MapMarkerManager.swift
@@ -1,7 +1,7 @@
 import NMapsMap
 
 class MapMarkerManager {
-    // 킥보드 id별 마커 저장
+    // 킥보드 modelName 별 마커 저장
     private var markers: [String: NMFMarker] = [:]
     
     func addMarker( to mapView: NMFMapView, scooter: ScooterEntity, lat: Double, lng: Double, color: UIColor, onTap: ((ScooterEntity) -> Void)? = nil)
@@ -12,9 +12,9 @@ class MapMarkerManager {
         marker.iconImage = NMFOverlayImage(image: makeMarkerImage(color: color))
         marker.mapView = mapView
         
-        // ID 기준으로 저장
-        if let id = scooter.ownerID {
-            markers[id] = marker
+        // modelName 기준으로 저장
+        if let modelName = scooter.modelName {
+            markers[modelName] = marker
         }
         
         // 마커 눌렀을 때 동작
@@ -49,8 +49,8 @@ class MapMarkerManager {
     
     // 마커 제거
     func removeMarker(for scooter: ScooterEntity) {
-        guard let id = scooter.ownerID, let marker = markers[id] else { return }
+        guard let modelName = scooter.modelName, let marker = markers[modelName] else { return }
         marker.mapView = nil
-        markers.removeValue(forKey: id)
+        markers.removeValue(forKey: modelName)
     }
 }


### PR DESCRIPTION
### 작업한 내용

> 해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
> 뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

A 킥보드를 대여하면 A 킥보드의 마커가 지도에서 사라지게 하는 기능이 있습니다. 기존에는 마커를 `ownerID`를 기준으로 저장했는데, 이는 **킥보드가 아닌 계정을 식별하는 고유값**이기 때문에 이와 같은 버그가 생긴다고 생각했습니다.
이를 해결하기 위해  **개체 고유 식별자 역할**을 하는 `modelName`으로 수정했습니다.


### 관련 이슈

Closes #116 

### PR 올리기 전 Check List

**Merge 대상 브랜치가 올바른가?** 네

작업한 코드가 에러 없이 잘 동작하는가? 네
